### PR TITLE
Avoid dev requirements in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,7 @@
 envlist = py27, py34
 
 [testenv]
-deps = -rrequirements-dev.txt
+deps =
+    -rrequirements.txt
+    pytest
 commands = py.test tests


### PR DESCRIPTION
requirements-dev.txt contains tox itself, along with other unneeded stuff for running the tests.

This installs only the package dependencies + pytest in tox virtualenvs.