### PR TITLE
Change service response content_type to JSON

### DIFF
--- a/extruct/service.py
+++ b/extruct/service.py
@@ -7,7 +7,7 @@ from gevent import monkey
 # gevent monkey patching
 monkey.patch_all()
 
-from bottle import route, run, request
+from bottle import route, run, request, response
 
 import lxml.html
 from extruct.w3cmicrodata import MicrodataExtractor
@@ -22,6 +22,7 @@ def JSON(func):
 
 
 def async_extruct(url, microdata=True, jsonld=True):
+    response.content_type = 'application/json'
     resp = requests.get(url, timeout=30)
 
     parser = lxml.html.HTMLParser(encoding=resp.encoding)


### PR DESCRIPTION
The service is currently returning JSON content as `text/html` and I changed it to `application/json`.

I use a browser extension that highlights syntax when viewing source code files and it wasn't rendering JSON properly because of the response content type. :-)