### PR TITLE
Add extruct command line tool

### DIFF
--- a/extruct/tool.py
+++ b/extruct/tool.py
@@ -1,0 +1,60 @@
+import argparse
+import json
+
+import requests
+from extruct.jsonld import JsonLdExtractor
+from extruct.rdfa import RDFaExtractor
+from extruct.w3cmicrodata import MicrodataExtractor
+
+
+def metadata_from_url(url, microdata=True, jsonld=True, rdfa=True):
+    resp = requests.get(url, timeout=30)
+    result = {'url': url, 'status': '{} {}'.format(resp.status_code, resp.reason)}
+    try:
+        resp.raise_for_status()
+    except requests.exceptions.HTTPError:
+        return result
+
+    if microdata:
+        mde = MicrodataExtractor(nested=True)
+        result['microdata'] = mde.extract(resp.content, resp.url, resp.encoding)
+
+    if jsonld:
+        jsonlde = JsonLdExtractor()
+        result['json-ld'] = jsonlde.extract(resp.content, resp.url, resp.encoding)
+
+    if rdfa:
+        rdfae = RDFaExtractor()
+        result['rdfa'] = rdfae.extract(resp.content, resp.url, resp.encoding)
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('url', help='The target URL')
+    parser.add_argument(
+        '--microdata',
+        action='store_true',
+        default=False,
+        help='Extract W3C Microdata from the page.',
+    )
+    parser.add_argument(
+        '--jsonld',
+        action='store_true',
+        default=False,
+        help='Extract JSON-LD metadata from the page.',
+    )
+    parser.add_argument(
+        '--rdfa',
+        action='store_true',
+        default=False,
+        help='Extract RDFa metadata from the page.',
+    )
+    args = parser.parse_args()
+
+    if any((args.microdata, args.jsonld, args.rdfa)):
+        metadata = metadata_from_url(args.url, args.microdata, args.jsonld, args.rdfa)
+    else:
+        metadata = metadata_from_url(args.url)
+    return json.dumps(metadata, indent=2, sort_keys=True)

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,11 @@ setup(
     maintainer='Scrapinghub',
     maintainer_email='info@scrapinghub.com',
     url='https://github.com/scrapinghub/extruct',
+    entry_points={
+        'console_scripts': {
+            'extruct = extruct.tool:main',
+        }
+    },
     packages=find_packages(exclude=['tests',]),
     package_data={'extruct': ['VERSION']},
     install_requires=['lxml'],

--- a/tests/samples/songkick/tovestyrke.html
+++ b/tests/samples/songkick/tovestyrke.html
@@ -1,0 +1,990 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:og="http://opengraphprotocol.org/schema/" xmlns:fb="http://www.facebook.com/2008/fbml">
+  <head prefix="og: http://ogp.me/ns# fb: http://www.facebook.com/2008/fbml songkick-concerts: http://ogp.me/ns/fb/songkick-concerts#">
+    <link rel="stylesheet" type="text/css" href="//assets.sk-static.com/assets/concert-b206345.css">
+    <script type="text/javascript">
+  SK = typeof(SK) == 'undefined' ? {} : SK;
+  SK_ASSET_HOST = "//assets.sk-static.com";
+  SK_DYNAMIC_ASSET_HOST = "https://images.sk-static.com";
+  CX_EXPERIMENT_ID = "";
+  CX_VARIATION_ID = -2;
+</script>
+
+    <title>Tove Styrke London Tickets, Hoxton Square Bar &amp; Kitchen, 12 Jun 2017 – Songkick</title>
+    <link href="//images.sk-static.com/images/media/profile_images/artists/3407026/col3" rel="image_src">
+    <link rel="shortcut icon" type="image/x-icon" href="//assets.sk-static.com/images/favicon.ico" />
+    <link href="//assets.sk-static.com/images/apple-touch-icon.png" rel="apple-touch-icon">
+    <link href="//assets.sk-static.com/images/apple-touch-icon.png" rel="apple-touch-icon-precomposed">
+    <meta name="robots" content="all">
+    <link href="http://www.songkick.com/concerts/30166884-tove-styrke-at-hoxton-square-bar-and-kitchen" rel="canonical">
+        <meta property="al:ios:url" content="songkick://events/30166884-tove-styrke-at-hoxton-square-bar-and-kitchen">
+    <meta property="al:ios:app_store_id" content="438690886">
+    <meta property="al:ios:app_name" content="Songkick Concerts">
+    <link rel="alternate" href="android-app://com.songkick/http/www.songkick.com/concerts/30166884-tove-styrke-at-hoxton-square-bar-and-kitchen">
+    <meta name="description" content="Buy tickets for Tove Styrke’s upcoming concert with Geowulf at Hoxton Square Bar &amp; Kitchen in London on 12 Jun 2017.">
+    <meta property="fb:app_id" content="308540029359">
+    <meta name="viewport" content="user-scalable=no, initial-scale=1.0, maximum-scale=1.0, width=device-width">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta property="og:site_name" content="Songkick">
+    <meta property="og:type" content="songkick-concerts:concert">
+    <meta property="og:title" content="Tove Styrke at Hoxton Square Bar &amp; Kitchen (12 Jun 17) with Geowulf">
+    <meta property="og:description" content="Buy tickets for Tove Styrke’s upcoming concert with Geowulf at Hoxton Square Bar &amp; Kitchen in London on 12 Jun 2017.">
+    <meta property="og:url" content="https://www.songkick.com/concerts/30166884-tove-styrke-at-hoxton-square-bar-and-kitchen">
+    <meta property="og:image" content="http://images.sk-static.com/images/media/img/col6/20170515-103345-171924.jpg">
+    <meta property="og:locality" content="London">
+    <meta property="og:country-name" content="UK">
+    <meta property="og:street-address" content="2-4 Hoxton Square">
+    <meta property="og:postal-code" content="N1 6NU">
+    <meta property="og:latitude" content="51.527476">
+    <meta property="og:longitude" content="-0.081657">
+  </head>
+  <body>
+    <script>
+  !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+  n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+  document,'script','//connect.facebook.net/en_US/fbevents.js');
+  fbq('init', '583609881778767');
+  fbq('track', 'PageView');
+</script>
+<noscript>
+  <img height="1" width="1" alt="" style="display:none" src="https://www.facebook.com/tr?id=583609881778767&amp;ev=PageView&amp;noscript=1" />
+</noscript>
+
+    <div id="fb-root"></div>
+
+
+
+    <div class="track-alert js-track-alert ">
+  <div class="track-alert-inner">
+    This event has been added to your <a data-analytics-category="navigation_your_plans" data-analytics-label="feedback_your_plans" href="/calendar?filter=attendance">Plans</a>.
+    <a class="track-alert-dismiss js-track-alert-dismiss">Close</a>
+  </div>
+</div>
+
+
+    <div class="navigation">
+        <div class="navigation-large-screen">
+  <ul class="nav-bar">
+    <li class="sub-nav">
+      <ul>
+        <li class="logo"><a href="/" data-analytics-category="navigation" data-analytics-label="logo"><img src="//assets.sk-static.com/assets/nw/furniture/songkick-logo-ac43b7a.svg" height="26" width="90" alt="songkick"></a>
+        </li><li class="metro-area menu hover-for-touch">
+          <a href="/metro_areas/24426-uk-london" data-analytics-category="navigation" data-analytics-label="metro_area" title="London concerts">London concerts</a>
+          <div class="menu-content">
+            <a href="/metro_areas/24426-uk-london" data-analytics-category="navigation" data-analytics-label="popular_tickets"><span>Popular tickets in London</span></a>
+            <a class="repeat" href="/metro_areas/24426-uk-london" data-analytics-category="navigation" data-analytics-label="metro_area">London concerts</a>
+              <ul class="listing">
+                <li class="event">
+                  <a href="/concerts/30305039-arcade-fire-at-york-hall" class="col" data-analytics-category="navigation" data-analytics-label="metro_area_popular_ticket">
+                  <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/66758/avatar" width="35" height="35" class="artist-profile-image artist" alt="Arcade Fire live">
+                  <span class="col"><span class="name">Arcade Fire</span><br>
+                    <span class="venue">York Hall</span>
+                </span></a></li>
+                <li class="event">
+                  <a href="/concerts/30323639-katy-perry-at-o2-arena" class="col" data-analytics-category="navigation" data-analytics-label="metro_area_popular_ticket">
+                  <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/1134363/avatar" width="35" height="35" class="artist-profile-image artist" alt="Katy Perry live">
+                  <span class="col"><span class="name">Katy Perry</span><br>
+                    <span class="venue">The O2 Arena</span>
+                </span></a></li>
+                <li class="event">
+                  <a href="/concerts/30180619-grizzly-bear-at-o2-academy-brixton" class="col" data-analytics-category="navigation" data-analytics-label="metro_area_popular_ticket">
+                  <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/469032/avatar" width="35" height="35" class="artist-profile-image artist" alt="Grizzly Bear live">
+                  <span class="col"><span class="name">Grizzly Bear</span><br>
+                    <span class="venue">O2 Academy Brixton</span>
+                </span></a></li>
+                <li class="event">
+                  <a href="/concerts/30333934-breaking-benjamin-at-o2-forum-kentish-town" class="col" data-analytics-category="navigation" data-analytics-label="metro_area_popular_ticket">
+                  <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/99074/avatar" width="35" height="35" class="artist-profile-image artist" alt="Breaking Benjamin live">
+                  <span class="col"><span class="name">Breaking Benjamin</span><br>
+                    <span class="venue">O2 Forum Kentish Town</span>
+                </span></a></li>
+                <li class="event">
+                  <a href="/concerts/30180764-royal-blood-at-alexandra-palace" class="col" data-analytics-category="navigation" data-analytics-label="metro_area_popular_ticket">
+                  <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/1421389/avatar" width="35" height="35" class="artist-profile-image artist" alt="Royal Blood live">
+                  <span class="col"><span class="name">Royal Blood</span><br>
+                    <span class="venue">Alexandra Palace</span>
+                </span></a></li>
+                <li class="event">
+                  <a href="/concerts/30219904-stone-sour-at-o2-academy-brixton" class="col" data-analytics-category="navigation" data-analytics-label="metro_area_popular_ticket">
+                  <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/73489/avatar" width="35" height="35" class="artist-profile-image artist" alt="Stone Sour live">
+                  <span class="col"><span class="name">Stone Sour</span><br>
+                    <span class="venue">O2 Academy Brixton</span>
+                </span></a></li>
+                <li class="event">
+                  <a href="/concerts/30348904-banks-at-eventim-apollo" class="col" data-analytics-category="navigation" data-analytics-label="metro_area_popular_ticket">
+                  <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/675567/avatar" width="35" height="35" class="artist-profile-image artist" alt="BANKS live">
+                  <span class="col"><span class="name">BANKS</span><br>
+                    <span class="venue">Eventim Apollo</span>
+                </span></a></li>
+                <li class="event">
+                  <a href="/concerts/30306409-daryl-hall-at-o2-arena" class="col" data-analytics-category="navigation" data-analytics-label="metro_area_popular_ticket">
+                  <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/164266/avatar" width="35" height="35" class="artist-profile-image artist" alt="Daryl Hall live">
+                  <span class="col"><span class="name">Daryl Hall</span><br>
+                    <span class="venue">The O2 Arena</span>
+                </span></a></li>
+                <li class="event">
+                  <a href="/concerts/29441389-nightmares-on-wax-at-jazz-cafe" class="col" data-analytics-category="navigation" data-analytics-label="metro_area_popular_ticket">
+                  <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/439542/avatar" width="35" height="35" class="artist-profile-image artist" alt="Nightmares On Wax live">
+                  <span class="col"><span class="name">Nightmares On Wax</span><br>
+                    <span class="venue">The Jazz Cafe</span>
+                </span></a></li>
+                <li class="event">
+                  <a href="/concerts/30167434-marilyn-manson-at-sse-arena-wembley" class="col" data-analytics-category="navigation" data-analytics-label="metro_area_popular_ticket">
+                  <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/317102/avatar" width="35" height="35" class="artist-profile-image artist" alt="Marilyn Manson live">
+                  <span class="col"><span class="name">Marilyn Manson</span><br>
+                    <span class="venue">SSE Arena, Wembley</span>
+                </span></a></li>
+              </ul>
+              <a href="/metro_areas/24426-uk-london" data-analytics-category="navigation" data-analytics-label="metro_area_see_all">See all London concerts</a> <a class="change-location" data-analytics-category="navigation" data-analytics-label="change_location" href="/session/filter_metro_area">(Change&nbsp;location)</a><br><br>
+              <a data-analytics-category="navigation" data-analytics-label="metro_area_today" href="/metro_areas/24426-uk-london?filters%5BmaxDate%5D=06%2F07%2F2017&amp;filters%5BminDate%5D=06%2F07%2F2017#date-filter-form">Today ·</a> <a data-analytics-category="navigation" data-analytics-label="metro_area_7days" href="/metro_areas/24426-uk-london?filters%5BmaxDate%5D=06%2F14%2F2017&amp;filters%5BminDate%5D=06%2F07%2F2017#date-filter-form">Next 7 days ·</a> <a data-analytics-category="navigation" data-analytics-label="metro_area_month" href="/metro_areas/24426-uk-london?filters%5BmaxDate%5D=07%2F07%2F2017&amp;filters%5BminDate%5D=06%2F07%2F2017#date-filter-form">Next 30 days</a>
+          </div>
+        </li>
+        <li class="artists menu hover-for-touch">
+            <a href="/metro_areas/24426-uk-london#popular-artists-in-metro-area" data-analytics-category="navigation" data-analytics-label="artists">Artists</a>
+          <div class="menu-content">
+                <ul class="artists-navigation">
+  <li class="col"><a href="/metro_areas/24426-uk-london#popular-artists-in-metro-area" data-analytics-category="navigation" data-analytics-label="popular_artists_metro_area">Popular artists in London</a></li>
+    <li class="col"><a href="/leaderboards/trending_artists" data-analytics-category="navigation" data-analytics-label="trending_artists">Trending artists worldwide</a></li>
+  </ul>
+  <div class="listing">
+      <ul class="col popular-artists">
+          <li>
+            <a href="/artists/1714170-giggs" data-analytics-category="navigation" data-analytics-label="artists_popular_artist_metro_area">
+              <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/1714170/avatar" width="35" height="35" class="artist-profile-image artist" alt="Giggs live">
+              <span class="name">Giggs</span>
+            </a>
+          </li>
+          <li>
+            <a href="/artists/8339588-stormzy" data-analytics-category="navigation" data-analytics-label="artists_popular_artist_metro_area">
+              <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/8339588/avatar" width="35" height="35" class="artist-profile-image artist" alt="Stormzy live">
+              <span class="name">Stormzy</span>
+            </a>
+          </li>
+          <li>
+            <a href="/artists/426367-jme" data-analytics-category="navigation" data-analytics-label="artists_popular_artist_metro_area">
+              <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/426367/avatar" width="35" height="35" class="artist-profile-image artist" alt="JME live">
+              <span class="name">JME</span>
+            </a>
+          </li>
+          <li>
+            <a href="/artists/19637-lethal-bizzle" data-analytics-category="navigation" data-analytics-label="artists_popular_artist_metro_area">
+              <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/19637/avatar" width="35" height="35" class="artist-profile-image artist" alt="Lethal Bizzle live">
+              <span class="name">Lethal Bizzle</span>
+            </a>
+          </li>
+          <li>
+            <a href="/artists/3933961-krept-and-konan" data-analytics-category="navigation" data-analytics-label="artists_popular_artist_metro_area">
+              <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/3933961/avatar" width="35" height="35" class="artist-profile-image artist" alt="Krept &amp; Konan live">
+              <span class="name">Krept &amp; Konan</span>
+            </a>
+          </li>
+      </ul>
+      <ul class="col popular-artists">
+          <li>
+            <a href="/artists/9063689-starley" data-analytics-category="navigation" data-analytics-label="artists_trending_artist">
+              <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/9063689/avatar" width="35" height="35" class="artist-profile-image artist" alt="Starley live">
+              <span class="name">Starley</span>
+            </a>
+          </li>
+          <li>
+            <a href="/artists/8997064-xxxtentacion" data-analytics-category="navigation" data-analytics-label="artists_trending_artist">
+              <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/8997064/avatar" width="35" height="35" class="artist-profile-image artist" alt="XXXTentacion live">
+              <span class="name">XXXTentacion</span>
+            </a>
+          </li>
+          <li>
+            <a href="/artists/9031399-ozuna" data-analytics-category="navigation" data-analytics-label="artists_trending_artist">
+              <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/9031399/avatar" width="35" height="35" class="artist-profile-image artist" alt="Ozuna live">
+              <span class="name">Ozuna</span>
+            </a>
+          </li>
+          <li>
+            <a href="/artists/894756-khalid" data-analytics-category="navigation" data-analytics-label="artists_trending_artist">
+              <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/894756/avatar" width="35" height="35" class="artist-profile-image artist" alt="Khalid live">
+              <span class="name">Khalid</span>
+            </a>
+          </li>
+          <li>
+            <a href="/artists/241457-nav" data-analytics-category="navigation" data-analytics-label="artists_trending_artist">
+              <img src="//assets.sk-static.com/assets/default_images/thumb/default-artist-ba18a04.png" data-src="//images.sk-static.com/images/media/profile_images/artists/241457/avatar" width="35" height="35" class="artist-profile-image artist" alt="NAV live">
+              <span class="name">NAV</span>
+            </a>
+          </li>
+      </ul>
+  </div>
+
+            <div class="tourbox-cta">
+              Get your tour dates seen by one billion fans: <a href="//tourbox.songkick.com/?utm_medium=referral&amp;utm_source=songkick.com&amp;utm_campaign=visitor" class="sign-up-as-an-artist" data-analytics-category="navigation" data-analytics-label="sign_up_tourbox">Sign up as an artist</a>
+            </div>
+          </div>
+        </li>
+        <li class="location">
+          <a data-analytics-category="navigation" data-analytics-label="change_location" href="/session/filter_metro_area">Change&nbsp;location</a>
+        </li>
+      </ul>
+    <li class="sub-nav">
+      <ul>
+        <li class="search">
+          <form name="search" class="navigation-search-form" data-analytics-category="navigation" data-analytics-label="search" action="/search" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+  <input type="hidden" name="type" value="initial">
+  <input name="query" type="search" value="" class="text navigation-search" placeholder="Enter artist / concert / venue"><button class="search-button" name="commit" type="submit"><img src="//assets.sk-static.com/assets/nw/components/navigation-large-screen/search-5510d8d.svg" height="15" width="14" alt="search" class="navigation-submit"></button>
+</form>
+        </li>
+        <li class="login-signup">
+          <a href="https://accounts.songkick.com/signup/new?source_product=skweb&amp;login_success_url=https%3A%2F%2Fwww.songkick.com%2Fconcerts%2F30166884-tove-styrke-at-hoxton-square-bar-and-kitchen&amp;signup_success_url=https%3A%2F%2Fwww.songkick.com%2Ftaste_imports%2Fnew" rel="nofollow" class="signup-link" data-signup-source="Everything else" data-analytics-category="navigation" data-analytics-label="sign_up">Sign up</a> <small>or</small> <a href="https://accounts.songkick.com/session/new?source_product=skweb&amp;login_success_url=https%3A%2F%2Fwww.songkick.com%2Fconcerts%2F30166884-tove-styrke-at-hoxton-square-bar-and-kitchen&amp;signup_success_url=https%3A%2F%2Fwww.songkick.com%2Ftaste_imports%2Fnew" rel="nofollow" data-analytics-category="navigation" data-analytics-label="log_in">Log in</a>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</div>
+
+        <div class="global-navigation">
+  <ul id='global-navigation-list'>
+    <li class="nav-icon"><a href="#nav-icon-toggle"><img src="//assets.sk-static.com/assets/nw/components/navigation/profile-menu-icon-b6e2b51.png" width="26" height="19" alt="Show navigation"></a></li>
+    <li id="nav-icon-toggle" class="nav"></li>
+    <li class="signup"><a href="https://accounts.songkick.com/signup/new?source_product=skweb&amp;login_success_url=https%3A%2F%2Fwww.songkick.com%2Fconcerts%2F30166884-tove-styrke-at-hoxton-square-bar-and-kitchen&amp;signup_success_url=https%3A%2F%2Fwww.songkick.com%2Ftaste_imports%2Fnew" rel="nofollow" class="signup-link" data-signup-source="Everything else" data-analytics-category="navigation" data-analytics-label="sign_up" data-auto-signup-redirect-url="https://itunes.apple.com/us/app/apple-store/id438690886?ct=%3A&amp;mt=8&amp;pt=307660">Sign up</a></li>
+    <li><a href="https://accounts.songkick.com/session/new?source_product=skweb&amp;login_success_url=https%3A%2F%2Fwww.songkick.com%2Fconcerts%2F30166884-tove-styrke-at-hoxton-square-bar-and-kitchen&amp;signup_success_url=https%3A%2F%2Fwww.songkick.com%2Ftaste_imports%2Fnew" rel="nofollow" data-analytics-category="navigation_small_screen" data-analytics-label="log_in">Log in</a></li>
+  </ul>
+  <a href="/" id="logo" data-analytics-category="navigation_small_screen" data-analytics-label="logo"><img src="//assets.sk-static.com/assets/nw/components/navigation/header-logo-ff8507a.png" alt="Songkick" width="124" height="32"></a>
+</div>
+<div class="local-navigation">
+  <ul>
+    <li class="nav-icon"><a href="#home"><img src="//assets.sk-static.com/assets/nw/components/navigation/local-navigation/navigation-icon-2eeeafe.png" width="22" height="15" alt="Show navigation"></a></li><li class="nav-icon search-nav"><label><a href="#search"><img src="//assets.sk-static.com/assets/nw/components/navigation/local-navigation/search-5cac59e.png" height="20" width="20" alt="search"></a></label></li>
+    <li class="site-search" id="search">
+      <form name="search" class="navigation-search-form" data-analytics-category="navigation" data-analytics-label="search" action="/search" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+  <input type="hidden" name="type" value="initial">
+  <input name="query" type="search" value="" class="text navigation-search" placeholder="Enter artist / concert / venue"><button class="search-button" name="commit" type="submit"><img src="//assets.sk-static.com/assets/nw/components/navigation-large-screen/search-5510d8d.svg" height="15" width="14" alt="search" class="navigation-submit"></button>
+</form>
+    </li>
+    <li class="home nav" id="home">
+      <a data-analytics-category="navigation" data-analytics-label="home" href="/">Home</a>
+    </li><li class="nav">
+      <a data-analytics-category="navigation" data-analytics-label="metro_area" href="/metro_areas/24426-uk-london">London concerts</a>
+    </li><li class="nav">
+      <a data-analytics-category="navigation" data-analytics-label="change_location" href="/session/filter_metro_area">Change&nbsp;location</a>
+    </li><li>
+      <a href="/leaderboards/popular_artists" data-analytics-catigory="navigation" data-analytics-label="popular_artists">Popular artists</a>
+    </li>
+  </ul>
+</div>
+
+    </div>
+
+      <div class="component see-all-events-for-headliner">
+  <p><a href="/artists/3407026-tove-styrke" data-analytics-category="navigation" data-analytics-label="event_strip_see_all"><img src="//assets.sk-static.com/images/nw/components/see-all-events-for-headliner/left-arrow.svg" alt="20" height="20" width="20">See all <span class="artist-name">Tove Styrke</span> concerts</a></p>
+</div>
+
+
+<div class="event-header">
+
+
+  <div class="row component brief">
+
+    <div class="col-8">
+      <div class="date-and-name">
+
+
+        <p>Monday 12 June 2017</p>
+      </div>
+
+      <h1 class="h0 summary">
+        <span><a data-analytics-category="event_brief" data-analytics-label="headliners" href="/artists/3407026-tove-styrke">Tove Styrke</a></span>
+      </h1>
+
+      <div class="location">
+        <span class="name"><a data-analytics-category="event_brief" data-analytics-label="venue_name" href="/venues/8280-hoxton-square-bar-and-kitchen">Hoxton Square Bar &amp; Kitchen</a>,</span>
+          <span>London, UK</span>
+
+      </div>
+
+        <div class="line-up">
+          Line-up:
+            <span class="headliner">
+              <a data-analytics-category="event_brief" data-analytics-label="line_up_artist" href="/artists/3407026-tove-styrke">Tove Styrke</a></span>,
+            <span >
+              <a data-analytics-category="event_brief" data-analytics-label="line_up_artist" href="/artists/8882079-geowulf">Geowulf</a></span>
+        </div>
+
+            <div class="join-cta"><a href="https://www.songkick.com/signup" data-analytics-category="event_brief" data-analytics-label="join_songkick">Join Songkick</a> to track this concert and we’ll remind you when it’s coming up.</div>
+
+          <div class="actions">
+            <div class="attendance">
+  <form class="attendance app-store-redirect auto-signup" data-stop-tracking-text="&lt;span class=&quot;icon&quot;&gt;&lt;/span&gt;&lt;span class=&quot;button-text&quot;&gt;Track event&lt;/span&gt;" data-tracking-text="&lt;span class=&quot;icon&quot;&gt;&lt;/span&gt;&lt;span class=&quot;button-text&quot;&gt;Track event&lt;/span&gt;" data-subject-upcoming="true" action="/trackings" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="jYCAA5dMj54x0CimQszwBzqiXE6zeflhK0iZmE8GwnBI9m+DggpywwV96gAnuwE6AHiVL9ijYSsI1PAL7is1/Q==" />
+    <input type="hidden" name="relationship_type" value="tracking">
+    <input type="hidden" name="subject_id" value="30166884">
+    <input type="hidden" name="subject_type" value="Event">
+    <input type="hidden" name="success_url" value="/concerts/30166884-tove-styrke-at-hoxton-square-bar-and-kitchen">
+    <input type="hidden" name="app_store_redirect_url" value="">
+    <button type="submit" class="tracking attendance-action" value="Track event"><span class="icon"></span><span class="button-text">Track event</span></button>
+</form>  <form class="attendance app-store-redirect auto-signup" data-stop-tracking-text="&lt;span class=&quot;icon&quot;&gt;&lt;/span&gt;&lt;span class=&quot;button-text&quot;&gt;I’m going&lt;/span&gt;" data-tracking-text="&lt;span class=&quot;icon&quot;&gt;&lt;/span&gt;&lt;span class=&quot;button-text&quot;&gt;I’m going&lt;/span&gt;" data-subject-upcoming="true" action="/trackings" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="WuCA5yHgv3+cpKMmqYA3K69Ijjn0i+6i10RtuV0oasWflm9nNKZCIqgJYYDM98YWlZJHWJ9Rduj02AQq/AWdSA==" />
+    <input type="hidden" name="relationship_type" value="im_going">
+    <input type="hidden" name="subject_id" value="30166884">
+    <input type="hidden" name="subject_type" value="Event">
+    <input type="hidden" name="success_url" value="/concerts/30166884-tove-styrke-at-hoxton-square-bar-and-kitchen">
+    <input type="hidden" name="app_store_redirect_url" value="">
+    <button type="submit" class="im-going attendance-action" value="I’m going"><span class="icon"></span><span class="button-text">I’m going</span></button>
+</form></div>
+
+          </div>
+
+    </div>
+
+    <div class="col-4">
+      <div class="profile-picture-and-actions">
+
+        <div class="profile-picture-wrapper">
+          <img class="profile-picture event" src="//images.sk-static.com/images/media/profile_images/artists/3407026/huge_avatar" alt="Tove Styrke live" title="Tove Styrke live" width="300" height="300">
+        </div>
+
+        <div class="event-moderation">
+          <div class="flag-event">
+            <a href="http://flagproblem.songkick.com/customer/portal/emails/new"
+               target="_blank"
+               data-analytics-category="event_brief"
+               data-analytics-label="flag_event">
+              Flag a problem
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<div class="container">
+  <div class="row">
+    <div class="col-8 primary">
+
+        <div id="tickets" class="component tickets-table tickets">
+  <h2>Buy tickets</h2>
+      <div class="ticket-wrapper">
+  <a href="/tickets/23419729?"  rel="nofollow"  title="Ticketweb UK"  data-analytics-category="ticket_vendor"  data-analytics-action="click_primary"  data-analytics-label="Ticketweb UK"  data-analytics-value="0"  target="_blank"  class="buy-ticket-row new-tab third-party">
+    <div class="ticket-cell">
+      <span class="vendor">Ticketweb UK
+      </span>
+
+    </div>
+    <div class="ticket-cell price-and-info">
+          <span class="price">
+            £10.00
+            <span class="addendum"></span>
+          </span>
+    </div>
+    <div class="ticket-cell buy-button-container">
+          <span class="sold-out">Sold out</span>
+    </div>
+  </a>
+</div>
+
+
+
+</div>
+
+        <div class="component event-hotness">
+    <div class="hotness-container">
+        <div class="venue-type">
+          <span class="hotness-title">Venue type</span>
+          <span class="hotness-data">Club (250 capacity)</span>
+        </div>
+    </div>
+  </div>
+
+        <div class="component event-timeline">
+    <div class="timeline-container">
+      <div class="timeline-fillable">
+        <div class="on-sale-time" style="width: 15%">
+          <div class="arrow-head"></div>
+          <span class="on-sale-time-copy">On sale for 22 days</span>
+        </div>
+        <div class="until-event-time">
+          <span class="until-event-time-copy">Event is in 5 days</span><br>
+        </div>
+      </div>
+    </div>
+  </div>
+
+
+
+      <div class="component venue-info">
+  <h2>Venue</h2>
+  <div class="venue-info-details">
+    <a class="url" href="/venues/8280-hoxton-square-bar-and-kitchen">Hoxton Square Bar &amp; Kitchen</a>
+    <p class="venue-hcard">
+  <span>
+      <span>2-4 Hoxton Square</span>
+      <span>N1 6NU</span>
+    <span>London, UK</span>
+  </span>
+    <span>+44 (0)20 7613 0709</span>
+    <span><a class="url" target="_blank" href="http://www.hoxtonsquarebar.com">www.hoxtonsquarebar.com</a></span>
+</p>
+
+    <a href="/venues/8280-hoxton-square-bar-and-kitchen">24 upcoming concerts</a>
+    <span class="capacity">Capacity: 250</span>
+  </div>
+</div>
+
+
+      <div class="component additional-details">
+  <h2>Additional details</h2>
+  <div class="additional-details-container">
+      <p>Doors open: 20:00</p>
+      <p>** THIS SHOW IS NOW SOLD OUT **</p>
+
+<p>Facebook Event: www.facebook.com/events/1252411554870762</p>
+  </div>
+</div>
+
+      <div class="component event-social">
+  <h2>Share this concert</h2>
+  <ul>
+    <li><a href="https://www.songkick.com/concerts/30166884-tove-styrke-at-hoxton-square-bar-and-kitchen?utm_campaign=event-page&amp;utm_content=ZD0yNDU3OTEy&amp;utm_medium=shared&amp;utm_source=facebook" class="facebook-share button social-sharing facebook" data-analytics-category="social_share" data-analytics-label="facebook" title="Share on Facebook"><span class="icon"></span><span class="button-text">Share</span></a></li>
+    <li><a href="https://twitter.com/share?url=https%3A%2F%2Fwww.songkick.com%2Fconcerts%2F30166884-tove-styrke-at-hoxton-square-bar-and-kitchen%3Futm_campaign%3Devent-page%26utm_content%3DZD0yNDU3OTEy%26utm_medium%3Dshared%26utm_source%3Dtwitter&amp;via=songkick" class="tweet twitter button social-sharing" data-analytics-category="social_share" data-analytics-label="twitter"  title="Share on twiter"><span class="icon"></span><span class="button-text">Tweet</span></a></li>
+    <li><a href="https://plus.google.com/share?url=https%3A%2F%2Fwww.songkick.com%2Fconcerts%2F30166884-tove-styrke-at-hoxton-square-bar-and-kitchen%3Futm_campaign%3Devent-page%26utm_content%3DZD0yNDU3OTEy%26utm_medium%3Dshared%26utm_source%3Dgoogleplus" class="googleplus button social-sharing googleplus" data-analytics-category="social_share" data-analytics-label="google" title="Share on Google+"><span class="icon"></span><span class="button-text">Share</span></a></li>
+  </ul>
+</div>
+
+
+      <div class="component expanded-lineup-details">
+  <h2>Line-up details</h2>
+  <ul>
+    <li class="headliner">
+      <div class="artist-image">
+        <a href="/artists/3407026-tove-styrke">
+          <img src="//images.sk-static.com/images/media/profile_images/artists/3407026/large_avatar" class="artist" alt="Tove Styrke live" />
+        </a>
+      </div>
+      <div class="artist-info">
+        <div class="headliner-label">HEADLINER</div>
+        <div class="main-details">
+          <span><a href="/artists/3407026-tove-styrke">Tove Styrke</a></span>
+          <a href="/artists/3407026-tove-styrke">7 upcoming events</a>
+        </div>
+        <div class="last-performance artist-details">
+          <p><strong>Last time in London:</strong> over 1 year ago</p>
+        </div>
+      </div>
+    </li>
+      <li class="non-headliner">
+        <div class="artist-image">
+          <a href="/artists/8882079-geowulf">
+            <img src="//images.sk-static.com/images/media/profile_images/artists/8882079/large_avatar" class="artist" alt="Tove Styrke live" />
+          </a>
+        </div>
+        <div class="artist-info">
+          <div class="main-details">
+            <span><a href="/artists/8882079-geowulf">Geowulf</a></span>
+            <a href="/artists/8882079-geowulf">1 upcoming event</a>
+          </div>
+          <div class="similarity artist-details">
+            <p><strong>Will you like them?</strong></p>
+            <div class="similarity-bar-container">
+              <span class="similarity-bar" style="width:20%;">
+                YOLO
+              </span>
+            </div>
+            <div class='message'>
+              Most fans of the headliner don’t know this artist. Be one of the first!
+            </div>
+          </div>
+        </div>
+      </li>
+  </ul>
+</div>
+
+      <div class="component artist-biographies">
+  <h2>Biographies</h2>
+  <ul>
+    <li class="biography-container">
+      <a href="/artists/3407026-tove-styrke#biography"><strong>Tove Styrke biography</strong></a>
+      <div class="artist-biography closed" >
+  <div class="standfirst">
+    <p>
+        Tove Styrke (born November 18, 1992) is a Swedish singer-songwriter who made her first impression on the Swedish public competing in Swedish Idol 2000 before embarking on a indie-pop solo career – hailing from Umeå, …
+    </p>
+      <span class="read-more-link-container"><a href="/artists/3407026-tove-styrke#biography">Read more</a></span>
+  </div>
+</div>
+
+    </li>
+  </ul>
+</div>
+
+      <div class="component artist-reviews">
+  <h2>Live reviews</h2>
+  <ul>
+
+    <li class="review-container" itemscope itemtype="http://schema.org/Review">
+        <span class="artist-name" itemprop="itemReviewed">Tove Styrke</span>
+      <strong><a href="/artists/3407026-tove-styrke#review-76107">Tove Styrke live review</a></strong>
+
+      <div class="review-content" itemprop="reviewBody" id="review-76107">
+    <p>Awesome energy and music, and even one or two of the songs from her debut album, Tove Styrke crushed it! Her music and stage presence are perfect for a venue like the Troubadour, where you can watch Tove pour her heart …</p>
+
+    <p>
+      <span class="read-more-link-container"><a class="" href="/artists/3407026-tove-styrke#review-76107">Read more</a></span>
+    </p>
+  <p><a href="http://flagproblem.songkick.com/customer/portal/emails/new" target="_blank"
+        data-analytics-category="artist_review"
+        data-analytics-label="report_review"
+        class="report-review">Report as inappropriate</a>
+  </p>
+</div>
+
+<div class="uploader">
+    <a href="/users/will-durrant">
+      <img class="uploader-profile-image" src="//images.sk-static.com/images/media/profile_images/users/28828564/medium_avatar" alt="will-durrant’s profile image">
+    <span><strong>by <span itemprop="author">will-durrant</span></strong></span>
+    </a>
+</div>
+
+    </li>
+  </ul>
+</div>
+
+
+
+      <div class="component media-summary">
+
+    <div class="media-group posters">
+  <h2>Posters (1)</h2>
+  <ul class="media-set posters inview" data-url="/concerts/30166884-tove-styrke-at-hoxton-square-bar-and-kitchen/posters" data-per-page="8" data-total="1">
+    <li>
+      <div class="media-element">
+  <a href="/posters/24535657" class="media-link" rel="nofollow" data-analytics-category="media_summary" data-analytics-label="poster">
+    <span class="icon-expand">
+      <img src="//assets.sk-static.com/images/nw/components/media-summary/icon-expand.svg" alt="expand" height="12" width="12">
+    </span>
+
+    <img src="//images.sk-static.com/images/media/img/col3/20170516-113736-663514.jpg" class="media-img" alt="Tove Styrke live" title="Tove Styrke live" width="220" height="311">
+  </a>
+</div>
+
+    </li>
+  </ul>
+
+  <nav class="media-nav">
+    <p class="browse"><a href="#posters" data-analytics-category="media_summary" data-analytics-label="see_all_posters">
+      See all posters (1)
+    </a></p>
+
+    <button class="paginate paginate-prev" data-analytics-category="media_summary" data-analytics-label="paginate_posters_prev">
+    </button>
+
+    <button class="paginate paginate-next" data-analytics-category="media_summary" data-analytics-label="paginate_posters_next">
+    </button>
+  </nav>
+</div>
+
+
+    <div class="media-group">
+  <h2>Photos (3)</h2>
+  <ul class="media-set images inview" data-url="/concerts/30166884-tove-styrke-at-hoxton-square-bar-and-kitchen/images" data-per-page="12" data-total="3">
+    <li>
+      <div class="media-element media-element-square">
+  <a class="media-link" rel="nofollow" data-analytics-category="media_summary" data-analytics-label="photo" href="/images/24520892">
+    <span class="icon-expand">
+      <img src="//assets.sk-static.com/images/nw/components/media-summary/icon-expand.svg" alt="expand" height="12" width="12">
+    </span>
+
+    <img class="media-img" alt="Tove Styrke live" title="Tove Styrke live" width="220" height="162" style="margin-top: -81px; margin-left: -110px;
+            min-height: 140px;" src="https://images.sk-static.com/images/media/img/col3/20170515-103345-171924.jpg" />
+</a></div>
+<div class="media-element media-element-square">
+  <a class="media-link" rel="nofollow" data-analytics-category="media_summary" data-analytics-label="photo" href="/images/15895312">
+    <span class="icon-expand">
+      <img src="//assets.sk-static.com/images/nw/components/media-summary/icon-expand.svg" alt="expand" height="12" width="12">
+    </span>
+
+    <img class="media-img" alt="Tove Styrke live" title="Tove Styrke live" width="220" height="146" style="margin-top: -73px; margin-left: -110px;
+            min-height: 140px;" src="https://images.sk-static.com/images/media/img/col3/20150708-150541-466883.jpg" />
+</a></div>
+<div class="media-element media-element-square">
+  <a class="media-link" rel="nofollow" data-analytics-category="media_summary" data-analytics-label="photo" href="/images/13526473">
+    <span class="icon-expand">
+      <img src="//assets.sk-static.com/images/nw/components/media-summary/icon-expand.svg" alt="expand" height="12" width="12">
+    </span>
+
+    <img class="media-img" alt="Tove Styrke live" title="Tove Styrke live" width="220" height="308" style="margin-top: -154px; margin-left: -110px;
+            min-height: 140px;" src="https://images.sk-static.com/images/media/img/col3/20141008-153342-272831.jpg" />
+</a></div>
+
+    </li>
+  </ul>
+
+  <nav class="media-nav">
+    <p class="browse"><a href="#images" data-analytics-category="media_summary" data-analytics-label="see_all_photos">
+      See all photos (3)
+    </a></p>
+
+    <button class="paginate paginate-prev" data-analytics-category="media_summary" data-analytics-label="paginate_photos_prev">
+    </button>
+
+    <button class="paginate paginate-next" data-analytics-category="media_summary" data-analytics-label="paginate_photos_next">
+    </button>
+  </nav>
+</div>
+
+</div>
+
+
+    </div><div class="col-4 secondary">
+
+      <div class="component related-events">
+  <div class="related-events-content">
+    <h5>Related upcoming events</h5>
+    <ol>
+        <li>
+          <a data-analytics-category="related_events" data-analytics-label="parent_event_id_30166884" href="/festivals/910659-barclaycard-british-summer-time/id/28754144-barclaycard-british-summer-time-2017">
+          Sunday 02 July 2017
+          <span class="event-title"><strong>Justin Bieber, Tove Lo, Martin Garrix, and Naughty Boy</strong>
+          Barclaycard British Summer Time 2017, London</span>
+</a>        </li>
+        <li>
+          <a data-analytics-category="related_events" data-analytics-label="parent_event_id_30166884" href="/festivals/113756-lovebox/id/28660059-lovebox-2017">
+          Friday 14 July 2017
+          <span class="event-title"><strong>Frank Ocean, Mac Miller, Chase &amp; Status, and Jess Glynne</strong>
+          Lovebox 2017, London</span>
+</a>        </li>
+        <li>
+          <a data-analytics-category="related_events" data-analytics-label="parent_event_id_30166884" href="/festivals/21956-south-west-four/id/29019994-south-west-four-2017">
+          Saturday 26 August 2017
+          <span class="event-title"><strong>Deadmau5, Pendulum, Eric Prydz, and Robin Schulz</strong>
+          South West Four 2017, Clapham</span>
+</a>        </li>
+        <li>
+          <a data-analytics-category="related_events" data-analytics-label="parent_event_id_30166884" href="/concerts/30348904-banks-at-eventim-apollo">
+          Wednesday 25 October 2017
+          <span class="event-title"><strong>BANKS</strong>
+          Eventim Apollo, London</span>
+</a>        </li>
+        <li>
+          <a data-analytics-category="related_events" data-analytics-label="parent_event_id_30166884" href="/concerts/30122844-mo-at-o2-academy-brixton">
+          Friday 27 October 2017
+          <span class="event-title"><strong>MØ</strong>
+          O2 Academy Brixton, London</span>
+</a>        </li>
+    </ol>
+  </div>
+</div>
+
+      <div class="component attendance-listing im-going">
+  <h5>18 people going</h5>
+  <ul>
+    <li>
+      <a href="/users/FintanStack" title="FintanStack" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/168326/medium_avatar" width="31" height="31" alt="FintanStack’s profile image" title="FintanStack’s profile image">
+        <span><strong>FintanStack</strong></span>
+      </a>
+    </li>
+    <li>
+      <a href="/users/moogmusic" title="moogmusic" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/3818446/medium_avatar" width="31" height="31" alt="moogmusic’s profile image" title="moogmusic’s profile image">
+        <span><strong>moogmusic</strong></span>
+      </a>
+    </li>
+    <li>
+      <a href="/users/newtonateapples" title="newtonateapples" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/14054853/medium_avatar" width="31" height="31" alt="newtonateapples’s profile image" title="newtonateapples’s profile image">
+        <span><strong>newtonateapples</strong></span>
+      </a>
+    </li>
+    <li>
+      <a href="/users/electronicrumors" title="electronicrumors" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/23113209/medium_avatar" width="31" height="31" alt="electronicrumors’s profile image" title="electronicrumors’s profile image">
+        <span><strong>electronicrumors</strong></span>
+      </a>
+    </li>
+    <li>
+      <a href="/users/lara-turner" title="lara-turner" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/33657998/medium_avatar" width="31" height="31" alt="lara-turner’s profile image" title="lara-turner’s profile image">
+        <span><strong>lara-turner</strong></span>
+      </a>
+    </li>
+    <li>
+      <a href="/users/le2374" title="le2374" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/50955834/medium_avatar" width="31" height="31" alt="le2374’s profile image" title="le2374’s profile image">
+        <span><strong>le2374</strong></span>
+      </a>
+    </li>
+    <li>
+      <a href="/users/Gavlaar5" title="Gavlaar5" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/106522654/medium_avatar" width="31" height="31" alt="Gavlaar5’s profile image" title="Gavlaar5’s profile image">
+        <span><strong>Gavlaar5</strong></span>
+      </a>
+    </li>
+    <li>
+      <a href="/users/pia-jeanette-mariana" title="pia-jeanette-mariana" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/117177754/medium_avatar" width="31" height="31" alt="pia-jeanette-mariana’s profile image" title="pia-jeanette-mariana’s profile image">
+        <span><strong>pia-jeanette-mariana</strong></span>
+      </a>
+    </li>
+    <li>
+      <a href="/users/sam-spence" title="sam-spence" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/117526989/medium_avatar" width="31" height="31" alt="sam-spence’s profile image" title="sam-spence’s profile image">
+        <span><strong>sam-spence</strong></span>
+      </a>
+    </li>
+    <li>
+      <a href="/users/leah-charlotte-mason" title="leah-charlotte-mason" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/117623519/medium_avatar" width="31" height="31" alt="leah-charlotte-mason’s profile image" title="leah-charlotte-mason’s profile image">
+        <span><strong>leah-charlotte-mason</strong></span>
+      </a>
+    </li>
+  </ul>
+</div>
+
+        <div class="component attendance-listing tracking">
+  <h5>22 people interested</h5>
+  <ul>
+    <li>
+      <a href="/users/tomrowlands" title="tomrowlands" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/91941/medium_avatar" width="31" height="31" alt="tomrowlands’s profile image" title="tomrowlands’s profile image">
+        <span><strong>tomrowlands</strong></span>
+      </a>
+    </li>
+    <li>
+      <a href="/users/jonathanhendry" title="jonathanhendry" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/28326164/medium_avatar" width="31" height="31" alt="jonathanhendry’s profile image" title="jonathanhendry’s profile image">
+        <span><strong>jonathanhendry</strong></span>
+      </a>
+    </li>
+    <li>
+      <a href="/users/leon-whitham" title="leon-whitham" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/30645509/medium_avatar" width="31" height="31" alt="leon-whitham’s profile image" title="leon-whitham’s profile image">
+        <span><strong>leon-whitham</strong></span>
+      </a>
+    </li>
+    <li>
+      <a href="/users/yiselle-lowrey" title="yiselle-lowrey" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/37544013/medium_avatar" width="31" height="31" alt="yiselle-lowrey’s profile image" title="yiselle-lowrey’s profile image">
+        <span><strong>yiselle-lowrey</strong></span>
+      </a>
+    </li>
+    <li>
+      <a href="/users/xrocksu" title="xrocksu" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/40357293/medium_avatar" width="31" height="31" alt="xrocksu’s profile image" title="xrocksu’s profile image">
+        <span><strong>xrocksu</strong></span>
+      </a>
+    </li>
+    <li>
+      <a href="/users/fridtjofeyvind" title="fridtjofeyvind" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/69592279/medium_avatar" width="31" height="31" alt="fridtjofeyvind’s profile image" title="fridtjofeyvind’s profile image">
+        <span><strong>fridtjofeyvind</strong></span>
+      </a>
+    </li>
+    <li>
+      <a href="/users/whatevsmacgregs" title="whatevsmacgregs" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/108153319/medium_avatar" width="31" height="31" alt="whatevsmacgregs’s profile image" title="whatevsmacgregs’s profile image">
+        <span><strong>whatevsmacgregs</strong></span>
+      </a>
+    </li>
+    <li>
+      <a href="/users/seyurie" title="seyurie" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/111099669/medium_avatar" width="31" height="31" alt="seyurie’s profile image" title="seyurie’s profile image">
+        <span><strong>seyurie</strong></span>
+      </a>
+    </li>
+    <li>
+      <a href="/users/luke-victor" title="luke-victor" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/116299804/medium_avatar" width="31" height="31" alt="luke-victor’s profile image" title="luke-victor’s profile image">
+        <span><strong>luke-victor</strong></span>
+      </a>
+    </li>
+    <li>
+      <a href="/users/claire-brisley" title="claire-brisley" rel="nofollow">
+        <img class="profile-picture photo user" src="//images.sk-static.com/images/media/profile_images/users/116957119/medium_avatar" width="31" height="31" alt="claire-brisley’s profile image" title="claire-brisley’s profile image">
+        <span><strong>claire-brisley</strong></span>
+      </a>
+    </li>
+  </ul>
+</div>
+
+      <div class="event-moderation-actions">
+  <div class="flag-event">
+    <a href="http://flagproblem.songkick.com/customer/portal/emails/new"
+       target="_blank"
+       data-analytics-category="event_brief"
+       data-analytics-label="flag_event">
+      Flag a problem
+    </a>
+  </div>
+</div>
+
+    </div>
+  </div>
+</div>
+
+<div class="microformat">
+  <script type="application/ld+json">[{"@context":"http://schema.org","@type":"MusicEvent","name":"Tove Styrke","url":"http://www.songkick.com/concerts/30166884-tove-styrke-at-hoxton-square-bar-and-kitchen?utm_medium=organic\u0026utm_source=microformat","location":{"@type":"Place","address":{"@type":"PostalAddress","addressLocality":"London","addressCountry":"UK","streetAddress":"2-4 Hoxton Square","postalCode":"N1 6NU"},"name":"Hoxton Square Bar \u0026 Kitchen","sameAs":"http://www.hoxtonsquarebar.com","geo":{"@type":"GeoCoordinates","latitude":51.527476,"longitude":-0.081657}},"startDate":"2017-06-12T20:00:00+0100","performer":[{"@type":"MusicGroup","name":"Tove Styrke","sameAs":"http://www.songkick.com/artists/3407026-tove-styrke?utm_medium=organic\u0026utm_source=microformat"},{"@type":"MusicGroup","name":"Geowulf","sameAs":"http://www.songkick.com/artists/8882079-geowulf?utm_medium=organic\u0026utm_source=microformat"}]}]</script>
+</div>
+
+
+
+
+
+    <div class="footer-container">
+      <div id="footer" class="container footer">
+  <div class="row">
+    <div class="col-3">
+      <ul>
+        <li><a href="/">Home</a></li>
+        <li><a href="/info/about" rel="nofollow">About us</a></li>
+        <li><a href="/partner">Partner with us</a></li>
+        <li><a href="/blog" rel="nofollow">Blog</a></li>
+        <li><a href="/jobs" rel="nofollow">Jobs</a></li>
+        <li><a href="http://support.songkick.com/">Help &amp; FAQ</a></li>
+        <li><a href="/leaderboards/popular_artists">Most popular charts</a></li>
+      </ul>
+    </div>
+    <div class="col-3">
+      <ul>
+        <li><a href="//tourbox.songkick.com/?utm_medium=referral&amp;utm_source=songkick.com&amp;utm_campaign=tourboxforartists">Tourbox for artists</a></li>
+        <li><a href="/developer"><abbr>API</abbr> information</a></li>
+        <li><a href="/info/guidelines" rel="nofollow">Community guidelines</a></li>
+        <li><a href="/info/terms" rel="nofollow">Terms of use</a></li>
+        <li><a href="/info/privacy" rel="nofollow">Privacy policy</a></li>
+        <li><a href="/info/security" rel="nofollow">Security</a></li>
+      </ul>
+    </div>
+    <div class="col-6">
+      <div class="tourbox-cta">
+        <p>Get your tour dates seen by one billion fans:</p>
+        <a href="//tourbox.songkick.com/?utm_medium=referral&amp;utm_source=songkick.com&amp;utm_campaign=visitor" class="sign-up-as-an-artist" data-analytics-category="navigation" data-analytics-label="sign_up_tourbox">Sign up as an artist</a>
+      </div>
+      <div class="social-container">
+        <ul class="social-icons">
+          <li>
+            <a href="https://twitter.com/songkick">
+              <img src="//assets.sk-static.com/assets/nw/furniture/icons/twitter-161f1e4.png" width="22" height="18" alt="Twitter">
+              &nbsp;<span>Follow us.</span>
+            </a>
+          </li>
+          <li>
+            <a href="http://www.facebook.com/songkick">
+              <img src="//assets.sk-static.com/assets/nw/furniture/icons/facebook-08359b5.png" width="18" height="18" alt="Facebook">
+              &nbsp;<span>Like us.</span>
+            </a>
+          </li>
+          <li>
+            <span>But we really hope you love us.</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+    </div>
+    <script type="text/javascript" src="//assets.sk-static.com/assets/manifests-1f4433a.js"></script><script type="text/javascript" src="//assets.sk-static.com/assets/app-60e1f1b.js"></script>
+
+    <script type="text/javascript">
+      Songkick.EventBus.bind('app:initialize', function(config) {
+        JS.require('jQuery', function() {
+          setTimeout(function()
+          {
+            $(".on-sale-time").css('width', '84.25925925925925%')
+          }, 500);
+        });
+      });
+    </script>
+  <script type="text/javascript">
+    Songkick.EventBus.bind('app:initialize', function(config) {
+      Songkick.EventBus.trigger('ui:event_page:artist_reviews:view', {});
+    });
+  </script>
+  <script type="text/javascript" src="//assets.sk-static.com/assets/event_page-d99195f.js"></script>
+  <script type="text/javascript">
+      Songkick.EventBus.bind('app:initialize', function() {
+        Songkick.EventBus.trigger('ui:event_page_upcoming:view', {tickets_label: "primary_tickets_only"});
+      });
+
+    Songkick.EventBus.bind('app:initialize', function() {
+      JS.require('jQuery', function() {
+        $(document).on('click', 'a.buy-ticket-row', function(e) {
+          Songkick.EventBus.trigger('ui:click', {
+            category: 'tmp_growth_team_ticket_vendor',
+            action: 'logged_out_click',
+            label: '30166884',
+            value: $(this).data('analytics-value')
+          });
+        });
+      });
+    });
+
+      Songkick.EventBus.bind('app:initialize', function(config) {
+        JS.require('jQuery.ui', function() {
+          var modal = new Songkick.Component.Modal({
+            analytics_category: 'signup_cta',
+            analytics_label: '30166884',
+            analytics_action_prefix: 'event:post_tv_click',
+            cookie_key: 'vendor-click-cta',
+            modal_class: 'vendor-signup-cta-container',
+            component: '<div class="top-area">  <button class="close-widget close">    <img src="/images/nw/components/vendor-click-signup-cta/close.svg" alt="Close" height="12" width="12">  </button>    <img alt="Tove Styrke live" width="70" height="70" class="artist artist-profile-image" src="//images.sk-static.com/images/media/profile_images/artists/3407026/large_avatar" />  <h2>Still searching for Tove Styrke tickets?</h2>  <p class="be-the-first-to-know">Be the first to know about tickets in the future.</p>  <p class="artist-trackings">31,257 other fans want alerts for this artist.</p></div><div class="bottom-area">  <div class="buttons">    <div class="tracking">  <form data-analytics-category="signup_cta" data-analytics-action="event:post_tv_click:cta_button" data-analytics-label="30166884" data-tracking-text="Yes, please notify me" data-stop-tracking-text="Yes, please notify me" class="app-store-redirect auto-signup" action="/trackings" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="D59a0IyWcL2D4uFHqULSYYVt8agoZ79FJRCiWHt3UWXK6bVQmdCN4LdPI+HMNSNcv7c4yUO9Jw8GjMvL2lqm6A==" />    <input type="hidden" name="relationship_type" value="concerts">    <input type="hidden" name="subject_id" value="3407026">    <input type="hidden" name="subject_type" value="Artist">    <input type="hidden" name="success_url" value="/concerts/30166884-tove-styrke-at-hoxton-square-bar-and-kitchen">    <input type="hidden" name="app_store_redirect_url" value="">    <button type="submit" class="artist signup-cta" value="Yes, please notify me">Yes, please notify me</button></form></div>    <a href="https://itunes.apple.com/us/app/apple-store/id438690886?ct=skweb%3Aevent%3Apost_tv_click%3Aapp_store_bt&amp;mt=8&amp;pt=307660" class="app-store-button" data-analytics-category="signup_cta" data-analytics-action="event:post_tv_click:app_store_bt" data-analytics-label="30166884">      <img src="//assets.sk-static.com/assets/nw/components/artist-off-tour-mobile/app-store-icon-e56abf8.svg" alt="Available on the App Store" class="store-button">    </a>    <a href="https://play.google.com/store/apps/details?id=com.songkick&amp;referrer=utm_campaign%3Devent%253Apost_tv_click%253Aapp_store_bt%26utm_medium%3D%26utm_source%3Dskweb" class="google-play-button" data-analytics-category="signup_cta" data-analytics-action="event:post_tv_click:app_store_bt" data-analytics-label="30166884">      <img src="//assets.sk-static.com/assets/nw/components/artist-off-tour-mobile/play-store-icon-79aae3f.svg" alt="Available on the Play Store" class="store-button">    </a>  </div>  <a class="close-message">I don’t want to hear about tickets</a></div>'
+          });
+          $('body').on('click', '.buy-ticket-row.third-party',
+            function(e) { modal.show(modal);});
+        });
+      });
+
+  </script>
+
+
+
+<script type="text/javascript">
+  /* <![CDATA[ */
+  var google_conversion_id = 964669843;
+  var google_custom_params = window.google_tag_params;
+  var google_remarketing_only = true;
+  /* ]]> */
+</script>
+<script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
+</script>
+<noscript>
+  <div style="display:inline;">
+  <img height="1" width="1" style="border-style:none;" alt="" src="//googleads.g.doubleclick.net/pagead/viewthroughconversion/964669843/?value=0&amp;guid=ON&amp;script=0"/>
+  </div>
+</noscript>
+
+<script type="text/javascript">
+  SK.logged_in_user = {
+    id:null,
+    analyticsUserType: 'visitor'
+  };
+
+  JS.require("FB", 'jQuery', function() {
+    Songkick.Facebook.init(
+      "308540029359",
+      ["email", "public_profile", "user_friends", "user_likes", "user_actions.music"],
+      ["email", "public_profile", "user_friends", "user_likes", "user_actions.music", "publish_actions"],
+      {events: Songkick.EventBus}
+    );
+  });
+  var features = {};
+  Songkick.EventBus.trigger('app:initialize', {
+    events: Songkick.EventBus,
+    features: features,
+    promoteNativeApp: false,
+    mobileSignupRedirectUrl: '',
+    mobileAnalyticsEnabled: false,
+  });
+</script>
+
+
+    <script>
+  (function(f,b){
+    var c;
+    f.hj=f.hj||function(){(f.hj.q=f.hj.q||[]).push(arguments)};
+    f._hjSettings={hjid:38507, hjsv:4};
+    c=b.createElement("script");c.async=1;
+    c.src="//static.hotjar.com/c/hotjar-"+f._hjSettings.hjid+".js?sv="+f._hjSettings.hjsv;
+    b.getElementsByTagName("head")[0].appendChild(c);
+  })(window,document);
+</script>
+
+
+  </body>
+</html>

--- a/tests/samples/songkick/tovestyrke.json
+++ b/tests/samples/songkick/tovestyrke.json
@@ -1,0 +1,137 @@
+{
+  "json-ld": [
+    {
+      "@context": "http://schema.org",
+      "@type": "MusicEvent",
+      "location": {
+        "@type": "Place",
+        "address": {
+          "@type": "PostalAddress",
+          "addressCountry": "UK",
+          "addressLocality": "London",
+          "postalCode": "N1 6NU",
+          "streetAddress": "2-4 Hoxton Square"
+        },
+        "geo": {
+          "@type": "GeoCoordinates",
+          "latitude": 51.527476,
+          "longitude": -0.081657
+        },
+        "name": "Hoxton Square Bar & Kitchen",
+        "sameAs": "http://www.hoxtonsquarebar.com"
+      },
+      "name": "Tove Styrke",
+      "performer": [
+        {
+          "@type": "MusicGroup",
+          "name": "Tove Styrke",
+          "sameAs": "http://www.songkick.com/artists/3407026-tove-styrke?utm_medium=organic&utm_source=microformat"
+        },
+        {
+          "@type": "MusicGroup",
+          "name": "Geowulf",
+          "sameAs": "http://www.songkick.com/artists/8882079-geowulf?utm_medium=organic&utm_source=microformat"
+        }
+      ],
+      "startDate": "2017-06-12T20:00:00+0100",
+      "url": "http://www.songkick.com/concerts/30166884-tove-styrke-at-hoxton-square-bar-and-kitchen?utm_medium=organic&utm_source=microformat"
+    }
+  ],
+  "microdata": [
+    {
+      "properties": {
+        "author": "will-durrant",
+        "itemReviewed": "Tove Styrke",
+        "reviewBody": "Awesome energy and music, and even one or two of the songs from her debut album, Tove Styrke crushed it! Her music and stage presence are perfect for a venue like the Troubadour, where you can watch Tove pour her heart …\n\n    \n      Read more\n    \n  Report as inappropriate"
+      },
+      "type": "http://schema.org/Review"
+    }
+  ],
+  "rdfa": [
+    {
+      "@id": "https://www.songkick.com/concerts/30166884-tove-styrke-at-hoxton-square-bar-and-kitchen",
+      "al:ios:app_name": [
+        {
+          "@value": "Songkick Concerts"
+        }
+      ],
+      "al:ios:app_store_id": [
+        {
+          "@value": "438690886"
+        }
+      ],
+      "al:ios:url": [
+        {
+          "@value": "songkick://events/30166884-tove-styrke-at-hoxton-square-bar-and-kitchen"
+        }
+      ],
+      "http://ogp.me/ns#country-name": [
+        {
+          "@value": "UK"
+        }
+      ],
+      "http://ogp.me/ns#description": [
+        {
+          "@value": "Buy tickets for Tove Styrke’s upcoming concert with Geowulf at Hoxton Square Bar & Kitchen in London on 12 Jun 2017."
+        }
+      ],
+      "http://ogp.me/ns#image": [
+        {
+          "@value": "http://images.sk-static.com/images/media/img/col6/20170515-103345-171924.jpg"
+        }
+      ],
+      "http://ogp.me/ns#latitude": [
+        {
+          "@value": "51.527476"
+        }
+      ],
+      "http://ogp.me/ns#locality": [
+        {
+          "@value": "London"
+        }
+      ],
+      "http://ogp.me/ns#longitude": [
+        {
+          "@value": "-0.081657"
+        }
+      ],
+      "http://ogp.me/ns#postal-code": [
+        {
+          "@value": "N1 6NU"
+        }
+      ],
+      "http://ogp.me/ns#site_name": [
+        {
+          "@value": "Songkick"
+        }
+      ],
+      "http://ogp.me/ns#street-address": [
+        {
+          "@value": "2-4 Hoxton Square"
+        }
+      ],
+      "http://ogp.me/ns#title": [
+        {
+          "@value": "Tove Styrke at Hoxton Square Bar & Kitchen (12 Jun 17) with Geowulf"
+        }
+      ],
+      "http://ogp.me/ns#type": [
+        {
+          "@value": "songkick-concerts:concert"
+        }
+      ],
+      "http://ogp.me/ns#url": [
+        {
+          "@value": "https://www.songkick.com/concerts/30166884-tove-styrke-at-hoxton-square-bar-and-kitchen"
+        }
+      ],
+      "http://www.facebook.com/2008/fbmlapp_id": [
+        {
+          "@value": "308540029359"
+        }
+      ]
+    }
+  ],
+  "status": "200 OK",
+  "url": "https://www.songkick.com/concerts/30166884-tove-styrke-at-hoxton-square-bar-and-kitchen"
+}

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,0 +1,112 @@
+import json
+import unittest
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+from extruct.tool import metadata_from_url
+from requests.exceptions import HTTPError
+from tests import get_testdata
+
+
+class TestTool(unittest.TestCase):
+
+    def setUp(self):
+        self.expected = json.loads(get_testdata('songkick', 'tovestyrke.json').decode('UTF-8'))
+        self.url = 'https://www.songkick.com/concerts/30166884-tove-styrke-at-hoxton-square-bar-and-kitchen'
+
+    @mock.patch('extruct.tool.requests.get')
+    def test_metadata_from_url_all_types(self, mock_get):
+        expected = self.expected
+        expected['url'] = self.url
+        expected['status'] = '200 OK'
+        mock_response = build_mock_response(
+            url=self.url,
+            content=get_testdata('songkick', 'tovestyrke.html'),
+        )
+        mock_get.return_value = mock_response
+
+        data = metadata_from_url(self.url)
+        self.assertEqual(data, expected)
+
+    @mock.patch('extruct.tool.requests.get')
+    def test_metadata_from_url_jsonld_only(self, mock_get):
+        expected = {
+            'json-ld': self.expected['json-ld'],
+            'url': self.url,
+            'status': '200 OK',
+        }
+        mock_response = build_mock_response(
+            url=self.url,
+            content=get_testdata('songkick', 'tovestyrke.html'),
+        )
+        mock_get.return_value = mock_response
+
+        data = metadata_from_url(self.url, microdata=False, jsonld=True, rdfa=False)
+        self.assertEqual(data, expected)
+
+    @mock.patch('extruct.tool.requests.get')
+    def test_metadata_from_url_microdata_only(self, mock_get):
+        expected = {
+            'microdata': self.expected['microdata'],
+            'url': self.url,
+            'status': '200 OK',
+        }
+        mock_response = build_mock_response(
+            url=self.url,
+            content=get_testdata('songkick', 'tovestyrke.html'),
+        )
+        mock_get.return_value = mock_response
+
+        data = metadata_from_url(self.url, microdata=True, jsonld=False, rdfa=False)
+        self.assertEqual(data, expected)
+
+    @mock.patch('extruct.tool.requests.get')
+    def test_metadata_from_url_rdfa_only(self, mock_get):
+        expected = {
+            'rdfa': self.expected['rdfa'],
+            'url': self.url,
+            'status': '200 OK',
+        }
+        mock_response = build_mock_response(
+            url=self.url,
+            content=get_testdata('songkick', 'tovestyrke.html'),
+        )
+        mock_get.return_value = mock_response
+
+        data = metadata_from_url(self.url, microdata=False, jsonld=False, rdfa=True)
+        self.assertEqual(data, expected)
+
+    @mock.patch('extruct.tool.requests.get')
+    def test_metadata_from_url_unauthorized_page(self, mock_get):
+        url = 'http://example.com/unauthorized'
+        expected = {
+            'url': url,
+            'status': '401 Unauthorized',
+        }
+        mock_response = build_mock_response(
+            url,
+            reason='Unauthorized',
+            status=401,
+        )
+        mock_get.return_value = mock_response
+        mock_response.raise_for_status.side_effect = http_error
+
+        data = metadata_from_url(url)
+        self.assertEqual(data, expected)
+
+
+def build_mock_response(url, encoding='utf-8', content='', reason='OK', status=200):
+    mock_response = mock.Mock()
+    mock_response.url = url
+    mock_response.encoding = encoding
+    mock_response.content = content
+    mock_response.reason = reason
+    mock_response.status_code = status
+    return mock_response
+
+
+def http_error():
+    raise HTTPError()

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,6 @@ deps =
     -rrequirements.txt
     pytest
     pytest-cov
+    mock
 
 commands = py.test --cov-report=term --cov-report= --cov=extruct {posargs:extruct tests}


### PR DESCRIPTION
Fixes https://github.com/scrapinghub/extruct/issues/27

This adds a command line tool called `extruct` that fetches a given URL and outputs the resulting metadata.

**Usage:**

    # outputs microdata, json-ld and rdfa found in the page
    $ extruct http://example.com
    
    # outputs only the microdata found in the page
    $ extruct --microdata http://example.com

    $ extruct --jsonld http://example.com

    $ extruct --rdfa http://example.com

    $ extruct --jsonld --rdfa http://example.com
