### PR TITLE
Silence rdflib logger to avoid message when importing

### DIFF
--- a/extruct/rdfa.py
+++ b/extruct/rdfa.py
@@ -6,6 +6,8 @@ Based on pyrdfa3 and rdflib
 """
 import json
 import logging
+rdflib_logger = logging.getLogger('rdflib')
+rdflib_logger.setLevel(logging.ERROR)
 
 from lxml.html import fromstring
 from rdflib import Graph, logger as rdflib_logger


### PR DESCRIPTION
`rdflib` displays this annoying log message when we import it. Thus, importing `extruct` gives us this:

    >>> import extruct
    INFO:rdflib:RDFLib Version: 4.2.2

This message is also displayed when we run `python -m extruct` and it's irrelevant to extruct, so this PR silences the `rdflib` logger before importing that module.