### PR TITLE
Allow control characters inside JSON-LD strings

### DIFF
--- a/extruct/jsonld.py
+++ b/extruct/jsonld.py
@@ -15,6 +15,12 @@ HTML_OR_JS_COMMENTLINE = re.compile('^(\s*//.*)|(\s*<!--.*-->\s*)')
 class JsonLdExtractor(object):
     _xp_jsonld = lxml.etree.XPath('descendant-or-self::script[@type="application/ld+json"]')
 
+    def __init__(self, allow_control_characters=True):
+        if allow_control_characters:
+            self.strict = False
+        else:
+            self.strict = True
+
     def extract(self, htmlstring, url='http://www.example.com/', encoding="UTF-8"):
         parser = lxml.html.HTMLParser(encoding=encoding)
         lxmldoc = lxml.html.fromstring(htmlstring, parser=parser)
@@ -32,7 +38,8 @@ class JsonLdExtractor(object):
             data = json.loads(script)
         except ValueError:
             # sometimes JSON-decoding errors are due to leading HTML or JavaScript comments
-            data = json.loads(HTML_OR_JS_COMMENTLINE.sub('', script))
+            data = json.loads(HTML_OR_JS_COMMENTLINE.sub('', script),
+                              strict=self.strict)
         if isinstance(data, list):
             return data
         elif isinstance(data, dict):

--- a/extruct/jsonld.py
+++ b/extruct/jsonld.py
@@ -16,10 +16,7 @@ class JsonLdExtractor(object):
     _xp_jsonld = lxml.etree.XPath('descendant-or-self::script[@type="application/ld+json"]')
 
     def __init__(self, allow_control_characters=True):
-        if allow_control_characters:
-            self.strict = False
-        else:
-            self.strict = True
+        self.strict = not allow_control_characters
 
     def extract(self, htmlstring, url='http://www.example.com/', encoding="UTF-8"):
         parser = lxml.html.HTMLParser(encoding=encoding)

--- a/tests/samples/control.characters/ControlCharacters.html
+++ b/tests/samples/control.characters/ControlCharacters.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>schema.org -- Restaurant</title>
+</head>
+<body>
+<script type="application/ld+json">
+    {
+      "@context": "http://schema.org",
+      "@type": "Restaurant",
+      "@id": "https://www.cosaordino.it/locale/838/bologna/costa-39-gelateria",
+      "name": "Costa 39 gelateria",
+      "image": "https://www.cosaordino.it//pictures/locale/wxthumb/1bd054d76743e70f6fc4ddd5c9d30013_thumb.jpg",
+      "sameAs": "https://www.cosaordino.it/locale/838/bologna/costa-39-gelateria",
+      "servesCuisine": "gelato",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "via Andrea Costa, 39",
+        "addressLocality": "Bologna",
+        "postalCode": "40134",
+        "addressRegion": "Bologna",
+        "addressCountry": "IT"
+      },
+      "telephone": "CosaordinoDelivery: 02-40031053	",
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 44.4946207,
+        "longitude": 11.3144884      },
+      "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "0",
+        "bestRating": "0",
+        "worstRating": "0",
+        "ratingCount": "0"
+      },
+      "potentialAction": {
+        "@type": "OrderAction",
+        "target": {
+            "actionPlatform": [
+                "http://schema.org/DesktopWebPlatform",
+                "http://schema.org/MobileWebPlatform"
+            ],
+            "inLanguage": "it-IT",
+            "url": "https://www.cosaordino.it/info/838/bologna/costa-39-gelateria"
+        },
+        "deliveryMethod": [
+            "http://purl.org/goodrelations/v1#DeliveryModeOwnFleet"
+        ]
+      }
+    }
+
+</script>
+</body>
+</html>

--- a/tests/samples/control.characters/ControlCharacters.jsonld
+++ b/tests/samples/control.characters/ControlCharacters.jsonld
@@ -1,0 +1,46 @@
+[
+    {
+        "servesCuisine": "gelato", 
+        "name": "Costa 39 gelateria", 
+        "sameAs": "https://www.cosaordino.it/locale/838/bologna/costa-39-gelateria", 
+        "geo": {
+            "latitude": 44.4946207, 
+            "@type": "GeoCoordinates", 
+            "longitude": 11.3144884
+        }, 
+        "image": "https://www.cosaordino.it//pictures/locale/wxthumb/1bd054d76743e70f6fc4ddd5c9d30013_thumb.jpg", 
+        "telephone": "CosaordinoDelivery: 02-40031053\t", 
+        "aggregateRating": {
+            "worstRating": "0", 
+            "bestRating": "0", 
+            "ratingCount": "0", 
+            "@type": "AggregateRating", 
+            "ratingValue": "0"
+        }, 
+        "potentialAction": {
+            "deliveryMethod": [
+                "http://purl.org/goodrelations/v1#DeliveryModeOwnFleet"
+            ], 
+            "@type": "OrderAction", 
+            "target": {
+                "url": "https://www.cosaordino.it/info/838/bologna/costa-39-gelateria", 
+                "inLanguage": "it-IT", 
+                "actionPlatform": [
+                    "http://schema.org/DesktopWebPlatform", 
+                    "http://schema.org/MobileWebPlatform"
+                ]
+            }
+        }, 
+        "address": {
+            "addressCountry": "IT", 
+            "addressLocality": "Bologna", 
+            "addressRegion": "Bologna", 
+            "streetAddress": "via Andrea Costa, 39", 
+            "postalCode": "40134", 
+            "@type": "PostalAddress"
+        }, 
+        "@context": "http://schema.org", 
+        "@id": "https://www.cosaordino.it/locale/838/bologna/costa-39-gelateria", 
+        "@type": "Restaurant"
+    }
+]

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -50,3 +50,10 @@ class TestJsonLD(unittest.TestCase):
         jsonlde = JsonLdExtractor()
         data = jsonlde.extract(body)
         self.assertEqual(data, expected)
+
+    def test_allow_control_characters_exception(self):
+        prefix = 'ControlCharacters'
+        body = get_testdata('control.characters', '{}.html'.format(prefix))
+
+        jsonlde = JsonLdExtractor(allow_control_characters=False)
+        self.assertRaises(ValueError, jsonlde.extract, body)

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -41,3 +41,12 @@ class TestJsonLD(unittest.TestCase):
             jsonlde = JsonLdExtractor()
             data = jsonlde.extract(body)
             self.assertEqual(data, expected)
+
+    def test_allow_control_characters(self):
+        prefix = 'ControlCharacters'
+        body = get_testdata('control.characters', '{}.html'.format(prefix))
+        expected = json.loads(get_testdata('control.characters', '{}.jsonld'.format(prefix)).decode('UTF-8'))
+
+        jsonlde = JsonLdExtractor()
+        data = jsonlde.extract(body)
+        self.assertEqual(data, expected)


### PR DESCRIPTION
As of now, control characters are not allowed inside strings, causing errors such as this one:

```
$ extruct "https://www.cosaordino.it/locale/887/monza-e-brianza/hambu"
Traceback (most recent call last):
  File "/home/pinky/.virtualenvs/richey-crawler/bin/extruct", line 11, in <module>
    sys.exit(main())
  File "/home/pinky/.virtualenvs/richey-crawler/local/lib/python2.7/site-packages/extruct/tool.py", line 64, in main
    metadata = metadata_from_url(args.url)
  File "/home/pinky/.virtualenvs/richey-crawler/local/lib/python2.7/site-packages/extruct/tool.py", line 29, in metadata_from_url
    result['json-ld'] = jsonlde.extract_items(tree, resp.url)
  File "/home/pinky/.virtualenvs/richey-crawler/local/lib/python2.7/site-packages/extruct/jsonld.py", line 25, in extract_items
    self._xp_jsonld(document))
  File "/home/pinky/.virtualenvs/richey-crawler/local/lib/python2.7/site-packages/extruct/jsonld.py", line 35, in _extract_items
    data = json.loads(HTML_OR_JS_COMMENTLINE.sub('', script))
  File "/usr/lib/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
    obj, end = self.scan_once(s, idx)
ValueError: Invalid control character at: line 18 column 52 (char 699)
```

This commit adds an option `allow_control_characters` to `JsonLdExtractor` to
set the `strict` parameter inside `json.loads`. default is true(strict=false),
based on @kmike's suggestion.

Thanks!