### PR TITLE
Fixing regex pattern to avoid removing comments from within valid JSON

### DIFF
--- a/extruct/jsonld.py
+++ b/extruct/jsonld.py
@@ -10,7 +10,7 @@ import lxml.etree
 import lxml.html
 
 
-HTML_OR_JS_COMMENTLINE = re.compile('^(\s*//.*)|(\s*<!--.*-->\s*)')
+HTML_OR_JS_COMMENTLINE = re.compile('^\s*(//.*|<!--.*-->)')
 
 class JsonLdExtractor(object):
     _xp_jsonld = lxml.etree.XPath('descendant-or-self::script[@type="application/ld+json"]')

--- a/tests/samples/custom.invalid/AllocateAction.001.html
+++ b/tests/samples/custom.invalid/AllocateAction.001.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+
+<head>
+    <title>schmea.org -- AllocateAction</title>
+</head>
+
+<body>
+<script type="application/ld+json">
+  // John allocated 5 hours to exercise.
+{
+  "@context": "http://schema.org",
+  "@type": "AllocateAction",
+  "agent": {
+    "@type": "Person",
+    "name": "John"
+  },
+  "object": {
+    "@type": "Duration",
+    "name": "5 hours"
+  },
+  "purpose": {
+    "@type": "ExercisePlan",
+    "name": "John's weight loss plan"
+  },
+	"rendered_js": "// John allocated 5 hours to exercise."
+}
+</script>
+</body>
+
+</html>

--- a/tests/samples/custom.invalid/AllocateAction.001.jsonld
+++ b/tests/samples/custom.invalid/AllocateAction.001.jsonld
@@ -1,0 +1,19 @@
+[
+    {
+      "@context": "http://schema.org",
+      "@type": "AllocateAction",
+      "agent": {
+        "@type": "Person",
+        "name": "John"
+      },
+      "object": {
+        "@type": "Duration",
+        "name": "5 hours"
+      },
+      "purpose": {
+        "@type": "ExercisePlan",
+        "name": "John's weight loss plan"
+      },
+      "rendered_js": "// John allocated 5 hours to exercise."
+    }
+]

--- a/tests/samples/custom.invalid/JoinAction.001.html
+++ b/tests/samples/custom.invalid/JoinAction.001.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+
+<head>
+    <title>schmea.org -- JoinAction</title>
+</head>
+
+<body>
+<script type="application/ld+json">
+<!-- John joined the festival. -->
+{
+  "@context": "http://schema.org",
+  "@type": "JoinAction",
+  "agent": {
+    "@type": "Person",
+    "name": "John"
+  },
+  "event": {
+    "@type": "Festival",
+    "name": "Woodstock"
+  },
+	"rendered_html": "<!-- John joined the festival. --><b>some text</b>"
+}
+</script>
+</body>
+
+</html>

--- a/tests/samples/custom.invalid/JoinAction.001.jsonld
+++ b/tests/samples/custom.invalid/JoinAction.001.jsonld
@@ -1,0 +1,9 @@
+[
+    {
+        "@type": "JoinAction",
+        "@context": "http://schema.org",
+        "agent": {"name": "John", "@type": "Person"},
+        "event": {"name": "Woodstock", "@type": "Festival"},
+        "rendered_html": "<!-- John joined the festival. --><b>some text</b>"
+    }
+]

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -41,3 +41,12 @@ class TestJsonLD(unittest.TestCase):
             jsonlde = JsonLdExtractor()
             data = jsonlde.extract(body)
             self.assertEqual(data, expected)
+        for prefix in ['JoinAction.001',
+                       'AllocateAction.001',
+                ]:
+            body = get_testdata('custom.invalid', '{}.html'.format(prefix))
+            expected = json.loads(get_testdata('custom.invalid', '{}.jsonld'.format(prefix)).decode('UTF-8'))
+
+            jsonlde = JsonLdExtractor()
+            data = jsonlde.extract(body)
+            self.assertEqual(data, expected)


### PR DESCRIPTION
See #62 for premise. This fixes the issue, and adds test-cases. The test cases duplicate the schema.org invalid files; I didn't want to edit them in place, as it would confuse their provenance.

I still wonder whether regex is the wrong way to fix prefixed/suffixed garbage, but a "correct" solution might be less efficient and harder to maintain. So perhaps it's best to shelve "correct" for now. :)