### PR TITLE
Flatten microformat children

### DIFF
--- a/extruct/uniform.py
+++ b/extruct/uniform.py
@@ -20,8 +20,19 @@ def _umicrodata_microformat(extracted, schema_context):
             res.append(flatten_dict(obj, schema_context, True))
     elif isinstance(extracted, dict):
         res.append(flatten_dict(extracted, schema_context, False))
-
     return res
+
+
+def flatten(element, schema_context):
+    if isinstance(element, dict):
+        element = flatten_dict(element, schema_context, False)
+    elif isinstance(element, list):
+        element = [
+            flatten_dict(o, schema_context, False)
+            if isinstance(o, dict) else o
+            for o in element
+        ]
+    return element
 
 
 def flatten_dict(d, schema_context, add_context):
@@ -36,34 +47,20 @@ def flatten_dict(d, schema_context, add_context):
     else:
         context, typ = infer_context(typ, schema_context)
         out['@type'] = typ
-    
+
     if add_context:
         out['@context'] = context
 
     props = out.pop('properties', {})
     for field, value in props.items():
-        if isinstance(value, dict):
-            value = flatten_dict(value, schema_context, False)
-        elif isinstance(value, list):
-            value = [
-                flatten_dict(o, schema_context, False)
-                if isinstance(o, dict) else o
-                for o in value
-            ]
+        value = flatten(value, schema_context)
         out[field] = value
 
     children = out.pop('children', [])
     if children:
         out['children'] = []
     for child in children:
-        if isinstance(child, dict):
-            child = flatten_dict(child, schema_context, False)
-        elif isinstance(child, list):
-            child = [
-                flatten_dict(o, schema_context, False)
-                if isinstance(o, dict) else o
-                for o in child
-            ]
+        child = flatten(child, schema_context)
         out['children'].append(child)
     return out
 

--- a/extruct/uniform.py
+++ b/extruct/uniform.py
@@ -23,7 +23,7 @@ def _umicrodata_microformat(extracted, schema_context):
     return res
 
 
-def flatten(element, schema_context):
+def _flatten(element, schema_context):
     if isinstance(element, dict):
         element = flatten_dict(element, schema_context, False)
     elif isinstance(element, list):
@@ -53,14 +53,14 @@ def flatten_dict(d, schema_context, add_context):
 
     props = out.pop('properties', {})
     for field, value in props.items():
-        value = flatten(value, schema_context)
+        value = _flatten(value, schema_context)
         out[field] = value
 
     children = out.pop('children', [])
     if children:
         out['children'] = []
     for child in children:
-        child = flatten(child, schema_context)
+        child = _flatten(child, schema_context)
         out['children'].append(child)
     return out
 

--- a/extruct/uniform.py
+++ b/extruct/uniform.py
@@ -51,6 +51,20 @@ def flatten_dict(d, schema_context, add_context):
                 for o in value
             ]
         out[field] = value
+
+    children = out.pop('children', [])
+    if children:
+        out['children'] = []
+    for child in children:
+        if isinstance(child, dict):
+            child = flatten_dict(child, schema_context, False)
+        elif isinstance(child, list):
+            child = [
+                flatten_dict(o, schema_context, False)
+                if isinstance(o, dict) else o
+                for o in child
+            ]
+        out['children'].append(child)
     return out
 
 

--- a/tests/samples/misc/microformat_flat_test.json
+++ b/tests/samples/misc/microformat_flat_test.json
@@ -1,33 +1,78 @@
 [
-    {
-        "@type": ["h-entry"],
-        "@context": "http://microformats.org/wiki/",
+  {
+    "@type": [
+      "h-hidden-tablet",
+      "h-hidden-phone"
+    ],
+    "@context": "http://microformats.org/wiki/",
+    "name": [
+      ""
+    ]
+  },
+  {
+    "@type": [
+      "h-hidden-phone"
+    ],
+    "@context": "http://microformats.org/wiki/",
+    "name": [
+      ""
+    ],
+    "children": [
+      {
+        "@type": [
+          "h-hidden-tablet",
+          "h-hidden-phone"
+        ],
         "name": [
-            "Microformats are amazing"
+          ""
+        ]
+      },
+      {
+        "@type": [
+          "h-hidden-phone"
         ],
-        "author": [
-            {
-                "@type": ["h-card"],
-                "name": [
-                    "W. Developer"
-                ],
-                "url": [
-                    "http://example.com"
-                ],
-                "value": "W. Developer"
-            }
+        "name": [
+          "aJ Styles FastLane 2018 15 x 17 Framed Plaque w/ Ring Canvas"
         ],
-        "published": [
-            "2013-06-13 12:00:00"
+        "photo": [
+          "/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg"
+        ]
+      }
+    ]
+  },
+  {
+    "@type": [
+      "h-entry"
+    ],
+    "@context": "http://microformats.org/wiki/",
+    "name": [
+      "Microformats are amazing"
+    ],
+    "author": [
+      {
+        "value": "W. Developer",
+        "@type": [
+          "h-card"
         ],
-        "summary": [
-            "In which I extoll the virtues of using microformats."
+        "name": [
+          "W. Developer"
         ],
-        "content": [
-            {
-                "html": "\n<p>Blah blah blah</p>\n",
-                "value": "\nBlah blah blah\n"
-            }
-            ]
-        }
+        "url": [
+          "http://example.com"
+        ]
+      }
+    ],
+    "published": [
+      "2013-06-13 12:00:00"
+    ],
+    "summary": [
+      "In which I extoll the virtues of using microformats."
+    ],
+    "content": [
+      {
+        "html": "\n<p>Blah blah blah</p>\n",
+        "value": "\nBlah blah blah\n"
+      }
+    ]
+  }
 ]

--- a/tests/samples/misc/microformat_test.html
+++ b/tests/samples/misc/microformat_test.html
@@ -7,6 +7,17 @@
 <link rel="stylesheet" type="text/css" href="event-education.css" />
 <meta name="verify-v1" content="so4y/3aLT7/7bUUB9f6iVXN0tv8upRwaccek7JKB1gs=" >
 <meta property="og:title" content="Himanshu's Open Graph Protocol"/>
+<div class="h-hidden-tablet h-hidden-phone"></div>
+	<div class="js-sticky-order b-header-pdp_sticky h-hidden-phone">
+		<div class="g-grid-container">
+			<div class="g-grid-row">
+				<div class="g-grid-col-1 h-hidden-tablet h-hidden-phone"></div>
+				<div class="g-grid-col-1 g-grid-col-2-tablet h-hidden-phone">
+					<img src="/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg" alt="aJ Styles FastLane 2018 15 x 17 Framed Plaque w/ Ring Canvas" />
+				</div>
+			</div>
+		</div>
+	</div>
 <article class="h-entry">
   <h1 class="p-name">Microformats are amazing</h1>
   <p>Published by <a class="p-author h-card" href="http://example.com">W. Developer</a>

--- a/tests/samples/misc/microformat_test.json
+++ b/tests/samples/misc/microformat_test.json
@@ -1,40 +1,87 @@
 [
-    {
+  {
+    "type": [
+      "h-hidden-tablet",
+      "h-hidden-phone"
+    ],
+    "properties": {
+      "name": [
+        ""
+      ]
+    }
+  },
+  {
+    "type": [
+      "h-hidden-phone"
+    ],
+    "properties": {
+      "name": [
+        ""
+      ]
+    },
+    "children": [
+      {
         "type": [
-            "h-entry"
+          "h-hidden-tablet",
+          "h-hidden-phone"
         ],
         "properties": {
-            "name": [
-                "Microformats are amazing"
-            ],
-            "author": [
-                {
-                    "type": [
-                        "h-card"
-                    ],
-                    "properties": {
-                        "name": [
-                            "W. Developer"
-                        ],
-                        "url": [
-                            "http://example.com"
-                        ]
-                    },
-                    "value": "W. Developer"
-                }
-            ],
-            "published": [
-                "2013-06-13 12:00:00"
-            ],
-            "summary": [
-                "In which I extoll the virtues of using microformats."
-            ],
-            "content": [
-                {
-                    "html": "\n<p>Blah blah blah</p>\n",
-                    "value": "\nBlah blah blah\n"
-                }
-            ]
+          "name": [
+            ""
+          ]
         }
+      },
+      {
+        "type": [
+          "h-hidden-phone"
+        ],
+        "properties": {
+          "name": [
+            "aJ Styles FastLane 2018 15 x 17 Framed Plaque w/ Ring Canvas"
+          ],
+          "photo": [
+            "/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "type": [
+      "h-entry"
+    ],
+    "properties": {
+      "name": [
+        "Microformats are amazing"
+      ],
+      "author": [
+        {
+          "type": [
+            "h-card"
+          ],
+          "properties": {
+            "name": [
+              "W. Developer"
+            ],
+            "url": [
+              "http://example.com"
+            ]
+          },
+          "value": "W. Developer"
+        }
+      ],
+      "published": [
+        "2013-06-13 12:00:00"
+      ],
+      "summary": [
+        "In which I extoll the virtues of using microformats."
+      ],
+      "content": [
+        {
+          "html": "\n<p>Blah blah blah</p>\n",
+          "value": "\nBlah blah blah\n"
+        }
+      ]
     }
+  }
 ]

--- a/tests/test_uniform.py
+++ b/tests/test_uniform.py
@@ -26,19 +26,32 @@ class TestUniform(unittest.TestCase):
         self.assertEqual(data['opengraph'], expected)
 
     def test_umicroformat(self):
-        expected = [{        "@context": "http://microformats.org/wiki/",
-                     "@type": ["h-entry"],
-                     "name": ["Microformats are amazing"],
-                     "author": [{"@type": ["h-card"],
-                                 "name": ["W. Developer"],
-                                 "url": ["http://example.com"],
-                                 "value": "W. Developer"}],
-                     "published": ["2013-06-13 12:00:00"],
-                     "summary": ["In which I extoll the virtues of using microformats."],
-                     "content": [{
-                                 "html": "\n<p>Blah blah blah</p>\n",
-                                 "value": "\nBlah blah blah\n"
-                                     }]}]
+        expected = [ { '@context': 'http://microformats.org/wiki/',
+                     '@type': ['h-hidden-tablet', 'h-hidden-phone'],
+                     'name': ['']},
+                   { '@context': 'http://microformats.org/wiki/',
+                     '@type': ['h-hidden-phone'],
+                     'children': [ { '@type': [ 'h-hidden-tablet',
+                                                'h-hidden-phone'],
+                                     'name': ['']},
+                                   { '@type': ['h-hidden-phone'],
+                                     'name': [ 'aJ Styles FastLane 2018 15 x '
+                                               '17 Framed Plaque w/ Ring '
+                                               'Canvas'],
+                                     'photo': [ '/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg']}],
+                     'name': ['']},
+                   { '@context': 'http://microformats.org/wiki/',
+                     '@type': ['h-entry'],
+                     'author': [ { '@type': ['h-card'],
+                                   'name': ['W. Developer'],
+                                   'url': ['http://example.com'],
+                                   'value': 'W. Developer'}],
+                     'content': [ { 'html': '\n<p>Blah blah blah</p>\n',
+                                    'value': '\nBlah blah blah\n'}],
+                     'name': ['Microformats are amazing'],
+                     'published': ['2013-06-13 12:00:00'],
+                     'summary': [ 'In which I extoll the virtues of using '
+                                  'microformats.']}]
         body = get_testdata('misc', 'microformat_test.html')
         data = extruct.extract(body, syntaxes=['microformat'], uniform=True)
         self.assertEqual(data['microformat'], expected)

--- a/tests/test_uniform.py
+++ b/tests/test_uniform.py
@@ -1,6 +1,6 @@
 import unittest
 import extruct
-# from tests import get_testdata, jsonize_dict
+from tests import get_testdata, jsonize_dict
 from extruct.uniform import _flatten, infer_context, flatten_dict
 
 

--- a/tests/test_uniform.py
+++ b/tests/test_uniform.py
@@ -1,7 +1,7 @@
 import unittest
 import extruct
-from tests import get_testdata, jsonize_dict
-from extruct.uniform import *
+# from tests import get_testdata, jsonize_dict
+from extruct.uniform import _flatten, infer_context, flatten_dict
 
 
 class TestUniform(unittest.TestCase):
@@ -132,4 +132,4 @@ class TestUniform(unittest.TestCase):
                                     '@type': ['h-hidden-phone']}],
                     'name': [''],
                     '@type': ['h-hidden-phone']}
-        self.assertEqual(flatten(d, schema_context='http://schema.org'), expected)
+        self.assertEqual(_flatten(d, schema_context='http://schema.org'), expected)

--- a/tests/test_uniform.py
+++ b/tests/test_uniform.py
@@ -3,8 +3,9 @@ import extruct
 from tests import get_testdata, jsonize_dict
 from extruct.uniform import *
 
+
 class TestUniform(unittest.TestCase):
-    
+
     maxDiff = None
 
     def test_uopengraph(self):
@@ -73,7 +74,7 @@ class TestUniform(unittest.TestCase):
                           "priceCurrency": "USD",
                           "price": "119.99",
                           "priceValidUntil": "2020-11-05",
-                          "seller": {"@type": "Organization", 
+                          "seller": {"@type": "Organization",
                                      "name": "Executive Objects"},
                           "itemCondition": "http://schema.org/UsedCondition",
                           "availability": "http://schema.org/InStock"
@@ -104,3 +105,31 @@ class TestUniform(unittest.TestCase):
                     "extra_weapon": "fear",
                     "another_one": "ruthless efficiency"}
         self.assertEqual(flatten_dict(d, schema_context='http://schema.org', add_context=True), expected)
+
+
+    def test_flatten(self):
+        d = { 'children': [ { 'properties': {'name': ['']},
+                                             'type': [ 'h-hidden-tablet',
+                                                       'h-hidden-phone']},
+                            { 'properties': { 'name': [ 'aJ Styles '
+                                                        'FastLane 2018 '
+                                                        '15 x 17 Framed '
+                                                        'Plaque w/ Ring '
+                                                        'Canvas'],
+                                              'photo': [ 'path.jpg']},
+                              'type': ['h-hidden-phone']}],
+              'properties': {'name': ['']},
+              'type': ['h-hidden-phone']}
+        expected = { 'children': [ { 'name': [''],
+                                     '@type': [ 'h-hidden-tablet',
+                                                'h-hidden-phone']},
+                                   { 'name': [ 'aJ Styles '
+                                               'FastLane 2018 '
+                                               '15 x 17 Framed '
+                                               'Plaque w/ Ring '
+                                               'Canvas'],
+                                    'photo': [ 'path.jpg'],
+                                    '@type': ['h-hidden-phone']}],
+                    'name': [''],
+                    '@type': ['h-hidden-phone']}
+        self.assertEqual(flatten(d, schema_context='http://schema.org'), expected)


### PR DESCRIPTION
some microformat pages return an extra ``children`` field that is structured as a list of dicts with ``type`` and ``properties``, eg:

```
{ 'children': [ { 'properties': {'name': ['']},
                                 'type': [ 'h-hidden-tablet',
                                           'h-hidden-phone']},
                { 'properties': { 'name': [ 'aJ Styles '
                                            'FastLane 2018 '
                                            '15 x 17 Framed '
                                            'Plaque w/ Ring '
                                            'Canvas'],
                                  'photo': [ '/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg']},
                  'type': ['h-hidden-phone']}],
  'properties': {'name': ['']},
  'type': ['h-hidden-phone']}
```

This PR flattens children structure like the parent elements

```
{ 'children': [ { 'name': ['']},
                  '@type': [ 'h-hidden-tablet',
                             'h-hidden-phone'],
                { 'name': [ 'aJ Styles '
                            'FastLane 2018 '
                            '15 x 17 Framed '
                            'Plaque w/ Ring '
                            'Canvas'],
                  'photo': [ '/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg']},
                  '@type': ['h-hidden-phone']}],
  'name': [''],
  '@type': ['h-hidden-phone']}
```