### PR TITLE
Use base_url instead of url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,8 +56,9 @@ Usage
 All-in-one extraction
 +++++++++++++++++++++
 
-The simplest example how to use extruct is to call ``extruct.extract(htmlstring, url)``
-with some HTML string and a URL.
+The simplest example how to use extruct is to call
+``extruct.extract(htmlstring, base_url=base_url)``
+with some HTML string and an optional base URL.
 
 Let's try this on a webpage that uses all the syntaxes supported (RDFa with `ogp`_).
 
@@ -66,10 +67,12 @@ First fetch the HTML using python-requests and then feed the response body to ``
   >>> import extruct
   >>> import requests
   >>> import pprint
+  >>> from w3lib.html import get_base_url
   >>>
   >>> pp = pprint.PrettyPrinter(indent=2)
   >>> r = requests.get('https://www.optimizesmart.com/how-to-use-open-graph-protocol/')
-  >>> data = extruct.extract(r.text, r.url)
+  >>> base_url = get_base_url(r.text, r.url)
+  >>> data = extruct.extract(r.text, base_url=base_url)
   >>>
   >>> pp.pprint(data)
   { 'json-ld': [ { '@context': 'https://schema.org',
@@ -167,7 +170,8 @@ Select syntaxes
 It is possible to select which syntaxes to extract by passing a list with the desired ones to extract. Valid values: 'microdata', 'json-ld', 'opengraph', 'microformat', 'rdfa'. If no list is passed all syntaxes will be extracted and returned::
 
   >>> r = requests.get('http://www.songkick.com/artists/236156-elysian-fields')
-  >>> data = extruct.extract(r.text, r.url, syntaxes=['microdata', 'opengraph', 'rdfa'])
+  >>> base_url = get_base_url(r.text, r.url)
+  >>> data = extruct.extract(r.text, base_url, syntaxes=['microdata', 'opengraph', 'rdfa'])
   >>>
   >>> pp.pprint(data)
   { 'microdata': [],
@@ -217,7 +221,8 @@ Another option is to uniform the output of microformat, opengraph, microdata and
 To do so set ``uniform=True`` when calling ``extract``, it's false by default for backward compatibility. Here the same example as before but with uniform set to True: ::
 
   >>> r = requests.get('http://www.songkick.com/artists/236156-elysian-fields')
-  >>> data = extruct.extract(r.text, r.url, syntaxes=['microdata', 'opengraph', 'rdfa'], uniform=True)
+  >>> base_url = get_base_url(r.text, r.url)
+  >>> data = extruct.extract(r.text, base_url, syntaxes=['microdata', 'opengraph', 'rdfa'], uniform=True)
   >>>
   >>> pp.pprint(data)
   { 'microdata': [],
@@ -387,7 +392,7 @@ RDFa extraction (experimental)
   ... """
   >>>
   >>> rdfae = RDFaExtractor()
-  >>> pp.pprint(rdfae.extract(html, url='http://www.example.com/index.html'))
+  >>> pp.pprint(rdfae.extract(html, base_url='http://www.example.com/index.html'))
   [{'@id': 'http://www.example.com/alice/posts/trouble_with_bob',
     '@type': ['http://schema.org/BlogPosting'],
     'http://purl.org/dc/terms/creator': [{'@id': 'http://www.example.com/index.html#me'}],
@@ -441,7 +446,7 @@ Open Graph extraction
   ... </html>"""
   >>>
   >>> opengraphe = OpenGraphExtractor()
-  >>> pp.pprint(opengraphe.extract(html, url='http://www.example.com/index.html'))
+  >>> pp.pprint(opengraphe.extract(html))
   [{"namespace": {
         "og": "http://ogp.me/ns#"
     },

--- a/extruct/jsonld.py
+++ b/extruct/jsonld.py
@@ -12,15 +12,16 @@ import lxml.html
 
 HTML_OR_JS_COMMENTLINE = re.compile('^\s*(//.*|<!--.*-->)')
 
+
 class JsonLdExtractor(object):
     _xp_jsonld = lxml.etree.XPath('descendant-or-self::script[@type="application/ld+json"]')
 
-    def extract(self, htmlstring, url=None, encoding="UTF-8"):
+    def extract(self, htmlstring, base_url=None, encoding="UTF-8"):
         parser = lxml.html.HTMLParser(encoding=encoding)
         lxmldoc = lxml.html.fromstring(htmlstring, parser=parser)
-        return self.extract_items(lxmldoc)
+        return self.extract_items(lxmldoc, base_url=base_url)
 
-    def extract_items(self, document, *args, **kwargs):
+    def extract_items(self, document, base_url=None):
         return [item for items in map(self._extract_items,
                                       self._xp_jsonld(document))
                      for item in items

--- a/extruct/microformat.py
+++ b/extruct/microformat.py
@@ -1,10 +1,11 @@
 import mf2py
 
+
 class MicroformatExtractor(object):
 
-    def extract(self, htmlstring, url=None, encoding='UTF-8'):
-        return list(self.extract_items(htmlstring, url=url))
+    def extract(self, htmlstring, base_url=None, encoding='UTF-8'):
+        return list(self.extract_items(htmlstring, base_url=base_url))
 
-    def extract_items(self, html, url, document=None):
-        for obj in mf2py.parse(html, html_parser="lxml", url=url)['items']:
+    def extract_items(self, html, base_url=None):
+        for obj in mf2py.parse(html, html_parser="lxml", url=base_url)['items']:
             yield obj

--- a/extruct/opengraph.py
+++ b/extruct/opengraph.py
@@ -5,12 +5,12 @@ import lxml.html
 class OpenGraphExtractor(object):
     """OpenGraph extractor following extruct API."""
 
-    def extract(self, htmlstring, url=None, encoding='UTF-8'):
+    def extract(self, htmlstring, base_url=None, encoding='UTF-8'):
         parser = lxml.html.HTMLParser(encoding=encoding)
         doc = lxml.html.fromstring(htmlstring, parser=parser)
-        return list(self.extract_items(doc))
+        return list(self.extract_items(doc, base_url=base_url))
 
-    def extract_items(self, document, *args, **kwargs):
+    def extract_items(self, document, base_url=None):
         # OpenGraph defines a web page as a single rich object.
         # TODO: Handle known opengraph namespaces.
         for head in document.xpath('//head'):

--- a/extruct/rdfa.py
+++ b/extruct/rdfa.py
@@ -29,14 +29,14 @@ initial_context["http://www.w3.org/2011/rdfa-context/rdfa-1.1"].ns.update({
 
 class RDFaExtractor(object):
 
-    def extract(self, htmlstring, url=None, encoding="UTF-8",
-            expanded=True):
+    def extract(self, htmlstring, base_url=None, encoding="UTF-8",
+                expanded=True):
 
         domparser = XmlDomHTMLParser(encoding=encoding)
         tree = fromstring(htmlstring, parser=domparser)
-        return self.extract_items(tree, url, expanded=expanded)
+        return self.extract_items(tree, base_url=base_url, expanded=expanded)
 
-    def extract_items(self, document, url, expanded=True, *args, **kwargs):
+    def extract_items(self, document, base_url=None, expanded=True):
         options = Options(output_processor_graph=True,
                           embedded_rdf=False,
                           space_preserve=True,
@@ -46,6 +46,6 @@ class RDFaExtractor(object):
                           refresh_vocab_cache=False,
                           check_lite=False)
 
-        g = PyRdfa(options, base=url).graph_from_DOM(document, graph=Graph(), pgraph=Graph())
+        g = PyRdfa(options, base=base_url).graph_from_DOM(document, graph=Graph(), pgraph=Graph())
         jsonld_string = g.serialize(format='json-ld', auto_compact=not expanded).decode('utf-8')
         return json.loads(jsonld_string)

--- a/tests/samples/schema.org/product_custom_url.json
+++ b/tests/samples/schema.org/product_custom_url.json
@@ -1,7 +1,7 @@
 [{"type": "http://schema.org/Product",
   "properties": {"brand": "ACME",
                  "name": "Executive Anvil",
-                 "image": "http://example.com/anvil_executive.jpg",
+                 "image": "http://some-example.com/anvil_executive.jpg",
                  "description": "Sleeker than ACME's Classic Anvil, the\n      Executive Anvil is perfect for the business traveler\n      looking for something to drop from a height.",
                  "mpn": "925872",
                  "aggregateRating": {"type": "http://schema.org/AggregateRating",

--- a/tests/test_extruct.py
+++ b/tests/test_extruct.py
@@ -5,6 +5,7 @@ import unittest
 import extruct
 from tests import get_testdata, jsonize_dict
 
+
 class TestGeneric(unittest.TestCase):
 
     maxDiff = None
@@ -12,5 +13,29 @@ class TestGeneric(unittest.TestCase):
     def test_all(self):
         body = get_testdata('songkick', 'elysianfields.html')
         expected = json.loads(get_testdata('songkick', 'elysianfields.json').decode('UTF-8'))
-        data = extruct.extract(body, 'http://www.songkick.com/artists/236156-elysian-fields')
+        data = extruct.extract(body, base_url='http://www.songkick.com/artists/236156-elysian-fields')
         self.assertEqual(jsonize_dict(data), expected)
+
+    def test_microdata_custom_url(self):
+        body, expected = self._microdata_custom_url()
+        data = extruct.extract(body, base_url='http://some-example.com',
+                               syntaxes=['microdata'])
+        self.assertEqual(data, expected)
+
+    def test_deprecated_url(self):
+        body, expected = self._microdata_custom_url()
+        data = extruct.extract(body, url='http://some-example.com',
+                               syntaxes=['microdata'])
+        self.assertEqual(data, expected)
+
+    def test_extra_kwargs(self):
+        body, expected = self._microdata_custom_url()
+        with self.assertRaises(TypeError):
+            extruct.extract(body, foo='bar')
+
+    def _microdata_custom_url(self):
+        body = get_testdata('schema.org', 'product.html')
+        expected = {'microdata': json.loads(
+            get_testdata('schema.org', 'product_custom_url.json')
+            .decode('UTF-8'))}
+        return body, expected

--- a/tests/test_microdata.py
+++ b/tests/test_microdata.py
@@ -169,5 +169,5 @@ class TestUrlJoin(unittest.TestCase):
         expected = json.loads(get_testdata('schema.org', 'product_custom_url.json').decode('UTF-8'))
 
         mde = MicrodataExtractor()
-        data = mde.extract(body, base_url='http://example.com')
+        data = mde.extract(body, base_url='http://some-example.com')
         self.assertEqual(data, expected)

--- a/tests/test_microdata.py
+++ b/tests/test_microdata.py
@@ -169,5 +169,5 @@ class TestUrlJoin(unittest.TestCase):
         expected = json.loads(get_testdata('schema.org', 'product_custom_url.json').decode('UTF-8'))
 
         mde = MicrodataExtractor()
-        data = mde.extract(body, url='http://example.com')
+        data = mde.extract(body, base_url='http://example.com')
         self.assertEqual(data, expected)

--- a/tests/test_rdfa.py
+++ b/tests/test_rdfa.py
@@ -50,7 +50,7 @@ class TestRDFa(unittest.TestCase):
                 ).decode('UTF-8'))
 
             rdfae = RDFaExtractor()
-            data = rdfae.extract(body, url='http://www.example.com/index.html')
+            data = rdfae.extract(body, base_url='http://www.example.com/index.html')
             self.assertJsonLDEqual(data, expected)
 
     def test_w3c_rdf11primer(self):
@@ -62,7 +62,7 @@ class TestRDFa(unittest.TestCase):
                 ).decode('UTF-8'))
 
             rdfae = RDFaExtractor()
-            data = rdfae.extract(body, url='http://www.example.com/index.html')
+            data = rdfae.extract(body, base_url='http://www.example.com/index.html')
             self.assertJsonLDEqual(data, expected)
 
     def test_w3c_rdfaprimer(self):
@@ -75,7 +75,7 @@ class TestRDFa(unittest.TestCase):
                        ).decode('UTF-8'))
 
             rdfae = RDFaExtractor()
-            data = rdfae.extract(body, url='http://www.example.com/index.html')
+            data = rdfae.extract(body, base_url='http://www.example.com/index.html')
             self.assertJsonLDEqual(data, expected)
 
     def test_wikipedia_xhtml_rdfa(self):
@@ -86,7 +86,7 @@ class TestRDFa(unittest.TestCase):
                    ).decode('UTF-8'))
 
         rdfae = RDFaExtractor()
-        data = rdfae.extract(body, url='http://www.example.com/index.html')
+        data = rdfae.extract(body, base_url='http://www.example.com/index.html')
 
         self.assertJsonLDEqual(data, expected)
 
@@ -97,6 +97,6 @@ class TestRDFa(unittest.TestCase):
                    ).decode('UTF-8'))
 
         rdfae = RDFaExtractor()
-        data = rdfae.extract(body, url='http://nielslubberman.nl/drupal/')
+        data = rdfae.extract(body, base_url='http://nielslubberman.nl/drupal/')
 
         self.assertJsonLDEqual(data, expected)


### PR DESCRIPTION
Fixes #75 

Changes:
- ``base_url`` is used instead of ``url`` in ``extruct.extract``, ``url`` is still supported by deprecated
- individual extractors accpet ``base_url`` instead of ``url``, unused keyword arguments are removed

TODO: 

- [x] add tests that make sure base_url is used
- [x] add tests for using deprectated url
- [x] rebase