### PR TITLE
Fix tests for microformats

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ gevent
 requests
 rdflib
 rdflib-jsonld
-mf2py==1.1.0
+mf2py>=1.1.0
 six
 w3lib

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ gevent
 requests
 rdflib
 rdflib-jsonld
-mf2py
+mf2py==1.1.0
 six
 w3lib

--- a/tests/samples/misc/microformat_flat_test.json
+++ b/tests/samples/misc/microformat_flat_test.json
@@ -1,78 +1,75 @@
 [
-  {
-    "@type": [
-      "h-hidden-tablet",
-      "h-hidden-phone"
-    ],
-    "@context": "http://microformats.org/wiki/",
-    "name": [
-      ""
-    ]
-  },
-  {
-    "@type": [
-      "h-hidden-phone"
-    ],
-    "@context": "http://microformats.org/wiki/",
-    "name": [
-      ""
-    ],
-    "children": [
-      {
+    {
         "@type": [
-          "h-hidden-tablet",
-          "h-hidden-phone"
+            "h-hidden-tablet",
+            "h-hidden-phone"
         ],
         "name": [
-          ""
-        ]
-      },
-      {
+            ""
+        ],
+        "@context": "http://microformats.org/wiki/"
+    },
+    {
         "@type": [
-          "h-hidden-phone"
+            "h-hidden-phone"
         ],
-        "name": [
-          "aJ Styles FastLane 2018 15 x 17 Framed Plaque w/ Ring Canvas"
-        ],
-        "photo": [
-          "/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg"
+        "@context": "http://microformats.org/wiki/",
+        "children": [
+            {
+                "@type": [
+                    "h-hidden-tablet",
+                    "h-hidden-phone"
+                ],
+                "name": [
+                    ""
+                ]
+            },
+            {
+                "@type": [
+                    "h-hidden-phone"
+                ],
+                "name": [
+                    "aJ Styles FastLane 2018 15 x 17 Framed Plaque w/ Ring Canvas"
+                ],
+                "photo": [
+                    "/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg"
+                ]
+            }
         ]
-      }
-    ]
-  },
-  {
-    "@type": [
-      "h-entry"
-    ],
-    "@context": "http://microformats.org/wiki/",
-    "name": [
-      "Microformats are amazing"
-    ],
-    "author": [
-      {
-        "value": "W. Developer",
+    },
+    {
+        "name": [
+            "Microformats are amazing"
+        ],
+        "@context": "http://microformats.org/wiki/",
         "@type": [
-          "h-card"
+            "h-entry"
         ],
-        "name": [
-          "W. Developer"
+        "summary": [
+            "In which I extoll the virtues of using microformats."
         ],
-        "url": [
-          "http://example.com"
+        "author": [
+            {
+                "@type": [
+                    "h-card"
+                ],
+                "url": [
+                    "http://example.com"
+                ],
+                "name": [
+                    "W. Developer"
+                ],
+                "value": "W. Developer"
+            }
+        ],
+        "content": [
+            {
+                "html": "<p>Blah blah blah</p>",
+                "value": "Blah blah blah"
+            }
+        ],
+        "published": [
+            "2013-06-13 12:00:00"
         ]
-      }
-    ],
-    "published": [
-      "2013-06-13 12:00:00"
-    ],
-    "summary": [
-      "In which I extoll the virtues of using microformats."
-    ],
-    "content": [
-      {
-        "html": "\n<p>Blah blah blah</p>\n",
-        "value": "\nBlah blah blah\n"
-      }
-    ]
-  }
+    }
 ]

--- a/tests/samples/misc/microformat_test.json
+++ b/tests/samples/misc/microformat_test.json
@@ -1,87 +1,83 @@
 [
-  {
-    "type": [
-      "h-hidden-tablet",
-      "h-hidden-phone"
-    ],
-    "properties": {
-      "name": [
-        ""
-      ]
-    }
-  },
-  {
-    "type": [
-      "h-hidden-phone"
-    ],
-    "properties": {
-      "name": [
-        ""
-      ]
-    },
-    "children": [
-      {
-        "type": [
-          "h-hidden-tablet",
-          "h-hidden-phone"
-        ],
+    {
         "properties": {
-          "name": [
-            ""
-          ]
-        }
-      },
-      {
-        "type": [
-          "h-hidden-phone"
-        ],
-        "properties": {
-          "name": [
-            "aJ Styles FastLane 2018 15 x 17 Framed Plaque w/ Ring Canvas"
-          ],
-          "photo": [
-            "/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg"
-          ]
-        }
-      }
-    ]
-  },
-  {
-    "type": [
-      "h-entry"
-    ],
-    "properties": {
-      "name": [
-        "Microformats are amazing"
-      ],
-      "author": [
-        {
-          "type": [
-            "h-card"
-          ],
-          "properties": {
             "name": [
-              "W. Developer"
-            ],
-            "url": [
-              "http://example.com"
+                ""
             ]
-          },
-          "value": "W. Developer"
-        }
-      ],
-      "published": [
-        "2013-06-13 12:00:00"
-      ],
-      "summary": [
-        "In which I extoll the virtues of using microformats."
-      ],
-      "content": [
-        {
-          "html": "\n<p>Blah blah blah</p>\n",
-          "value": "\nBlah blah blah\n"
-        }
-      ]
+        },
+        "type": [
+            "h-hidden-tablet",
+            "h-hidden-phone"
+        ]
+    },
+    {
+        "properties": {},
+        "children": [
+            {
+                "properties": {
+                    "name": [
+                        ""
+                    ]
+                },
+                "type": [
+                    "h-hidden-tablet",
+                    "h-hidden-phone"
+                ]
+            },
+            {
+                "properties": {
+                    "photo": [
+                        "/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg"
+                    ],
+                    "name": [
+                        "aJ Styles FastLane 2018 15 x 17 Framed Plaque w/ Ring Canvas"
+                    ]
+                },
+                "type": [
+                    "h-hidden-phone"
+                ]
+            }
+        ],
+        "type": [
+            "h-hidden-phone"
+        ]
+    },
+    {
+        "properties": {
+            "author": [
+                {
+                    "properties": {
+                        "url": [
+                            "http://example.com"
+                        ],
+                        "name": [
+                            "W. Developer"
+                        ]
+                    },
+                    "value": "W. Developer",
+                    "type": [
+                        "h-card"
+                    ]
+                }
+            ],
+            "name": [
+                "Microformats are amazing"
+            ],
+            "content": [
+                {
+                    "value": "Blah blah blah",
+                    "html": "<p>Blah blah blah</p>"
+                }
+            ],
+            "published": [
+                "2013-06-13 12:00:00"
+            ],
+            "summary": [
+                "In which I extoll the virtues of using microformats."
+            ]
+        },
+        "type": [
+            "h-entry"
+        ]
     }
-  }
 ]

--- a/tests/test_uniform.py
+++ b/tests/test_uniform.py
@@ -1,7 +1,8 @@
 import unittest
+
 import extruct
-from tests import get_testdata, jsonize_dict
 from extruct.uniform import _flatten, infer_context, flatten_dict
+from tests import get_testdata
 
 
 class TestUniform(unittest.TestCase):
@@ -40,21 +41,26 @@ class TestUniform(unittest.TestCase):
                                                '17 Framed Plaque w/ Ring '
                                                'Canvas'],
                                      'photo': [ '/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg']}],
-                     'name': ['']},
+                   },
                    { '@context': 'http://microformats.org/wiki/',
                      '@type': ['h-entry'],
                      'author': [ { '@type': ['h-card'],
                                    'name': ['W. Developer'],
                                    'url': ['http://example.com'],
                                    'value': 'W. Developer'}],
-                     'content': [ { 'html': '\n<p>Blah blah blah</p>\n',
-                                    'value': '\nBlah blah blah\n'}],
+                     'content': [ { 'html': '<p>Blah blah blah</p>',
+                                    'value': 'Blah blah blah'}],
                      'name': ['Microformats are amazing'],
                      'published': ['2013-06-13 12:00:00'],
                      'summary': [ 'In which I extoll the virtues of using '
                                   'microformats.']}]
         body = get_testdata('misc', 'microformat_test.html')
         data = extruct.extract(body, syntaxes=['microformat'], uniform=True)
+
+        print(data['microformat'])
+        print(), print(), print(), print()
+        print(expected)
+
         self.assertEqual(data['microformat'], expected)
 
     def test_umicrodata(self):

--- a/tests/test_uniform.py
+++ b/tests/test_uniform.py
@@ -56,11 +56,6 @@ class TestUniform(unittest.TestCase):
                                   'microformats.']}]
         body = get_testdata('misc', 'microformat_test.html')
         data = extruct.extract(body, syntaxes=['microformat'], uniform=True)
-
-        print(data['microformat'])
-        print(), print(), print(), print()
-        print(expected)
-
         self.assertEqual(data['microformat'], expected)
 
     def test_umicrodata(self):


### PR DESCRIPTION
It seems that new version of the library for parsing microformats have been updated recently and it causes that three tests does not pass anymore. I did the following here:
- I verified why exactly the tests fails. 
  * First of all `mf2py` seems to trim text in the content, so it means that signs of new line are removed. 
  * Second thing is that in some cases the name property has been removed from output. To be honest I don't understand why it happened, especially that it is not removed every time. Do you think we should care about that and ask them about that?
- I believe that we can just use this new version so I fixed all tests.
- I fixed the version of library in `requirements.txt` to 1.1.0.