### PR TITLE
Add raw json output to JsonLdExtractor

### DIFF
--- a/extruct/jsonld.py
+++ b/extruct/jsonld.py
@@ -16,26 +16,24 @@ HTML_OR_JS_COMMENTLINE = re.compile(r'^\s*(//.*|<!--.*-->)')
 class JsonLdExtractor(object):
     _xp_jsonld = lxml.etree.XPath('descendant-or-self::script[@type="application/ld+json"]')
 
-    def extract(self, htmlstring, base_url=None, encoding="UTF-8"):
+    def extract(self, htmlstring, base_url=None, encoding="UTF-8", as_json=False):
         tree = parse_html(htmlstring, encoding=encoding)
-        return self.extract_items(tree, base_url=base_url)
+        return self.extract_items(tree, base_url=base_url, as_json=as_json)
 
-    def extract_items(self, document, base_url=None):
+    def extract_items(self, document, base_url=None, as_json=False):
         return [
             item
-            for items in map(self._extract_items, self._xp_jsonld(document))
+            for items in map(self._extract_items_raw if as_json else self.extract_items, self._xp_jsonld(document))
             if items for item in items if item
         ]
 
+    def _extract_items_raw(self, node):
+        return HTML_OR_JS_COMMENTLINE.sub('', node.xpath('string()'))
+
     def _extract_items(self, node):
-        script = node.xpath('string()')
-        try:
-            # TODO: `strict=False` can be configurable if needed
-            data = json.loads(script, strict=False)
-        except ValueError:
-            # sometimes JSON-decoding errors are due to leading HTML or JavaScript comments
-            data = json.loads(
-                HTML_OR_JS_COMMENTLINE.sub('', script), strict=False)
+        script = self._extract_items_raw(node)
+        # TODO: `strict=False` can be configurable if needed
+        data = json.loads(script, strict=False)
         if isinstance(data, list):
             return data
         elif isinstance(data, dict):


### PR DESCRIPTION
Sometimes jsonld schema is prefered in raw json format rather than python dict - this PR implementes `as_json` kwarg bool to determine whether to return python dictionary or json string.

Some use cases:
    
    1. Use alternative json library
    2. Use json.loads kwargs
    3. Use object hook functions

My personal use case is to strip away `@` keys with object hook:

    def strip_jsonld(data):
        return {k: v for k, v in data.items() if not k.startswith('@')}

    data = json.loads(script, object_hook=strip_jsonld)

