### PR TITLE
Avoid including itemprop from child itemscopes when using itemref

### DIFF
--- a/extruct/w3cmicrodata.py
+++ b/extruct/w3cmicrodata.py
@@ -130,14 +130,16 @@ class LxmlMicrodataExtractor(object):
         if 'itemprop' in ref_node.keys() and 'itemscope' in ref_node.keys():
             # An full item will be extracted from the node, no need to look
             # for individual properties in childs
-            yield from extract_fn(ref_node)
+            for p, v in extract_fn(ref_node):
+                yield p, v
         else:
             base_parent_scope = ref_node.xpath("ancestor-or-self::*[@itemscope][1]")
             for prop in ref_node.xpath("descendant-or-self::*[@itemprop]"):
                 parent_scope = prop.xpath("ancestor::*[@itemscope][1]")
                 # Skip properties defined in a different scope than the ref_node
                 if parent_scope == base_parent_scope:
-                    yield from extract_fn(prop)
+                    for p, v in extract_fn(prop):
+                        yield p, v
 
     def _extract_property(self, node, items_seen, base_url):
         props = node.get("itemprop").split()

--- a/extruct/w3cmicrodata.py
+++ b/extruct/w3cmicrodata.py
@@ -79,17 +79,17 @@ class LxmlMicrodataExtractor(object):
                 item["id"] = itemid.strip()
 
         properties = collections.defaultdict(list)
-        # start with item references
+        for name, value in self._extract_properties(
+                node, items_seen=items_seen, base_url=base_url):
+            properties[name].append(value)
+
+        # process item references
         refs = node.get('itemref', '').split()
         if refs:
             for refid in refs:
                 for name, value in self._extract_property_refs(
                         node, refid, items_seen=items_seen, base_url=base_url):
                     properties[name].append(value)
-
-        for name, value in self._extract_properties(
-                node, items_seen=items_seen, base_url=base_url):
-            properties[name].append(value)
 
         props = []
         for (name, values) in properties.items():

--- a/tests/samples/schema.org/product-ref.html
+++ b/tests/samples/schema.org/product-ref.html
@@ -1,0 +1,55 @@
+<!DOCTYPE HTML>
+<html>
+ <head>
+  <title>Photo gallery</title>
+ </head>
+ <body>
+
+  <div id="product" itemscope itemtype="http://schema.org/Product" itemref="other-product-properties more-properties related_products">
+    <span itemprop="brand">ACME</span>
+    <span itemprop="name">Executive Anvil</span>
+    <img itemprop="image" src=" anvil_executive.jpg" alt="Executive Anvil logo"/>
+    <span itemprop="description">Sleeker than ACME's Classic Anvil, the
+      Executive Anvil is perfect for the business traveler
+      looking for something to drop from a height.
+    </span>
+    Product #: <span itemprop="mpn">925872</span>
+    <span id="aggregateRating" itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">
+      <span itemprop="ratingValue">4.4</span> stars, based on <span itemprop="reviewCount">89
+        </span> reviews
+    </span>
+
+    <span id="offer" itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+      Regular price: $179.99
+      <meta itemprop="priceCurrency" content="USD" />
+      $<span itemprop="price">119.99 </span>
+      (Sale ends <time itemprop="priceValidUntil" datetime="2020-11-05">
+        5 November!</time>)
+      Available from: <span id="organization" itemprop="seller" itemscope itemtype="http://schema.org/Organization">
+                        <span itemprop="name">Executive Objects</span>
+                      </span>
+      Condition: <link itemprop="itemCondition" href="http://schema.org/UsedCondition"/>Previously owned,
+        in excellent condition
+      <link itemprop="availability" href="  http://schema.org/InStock"/>In stock! Order now!
+    </span>
+  </div>
+  <div id="other-product-properties" itemscope itemtype="http://schema.org/Product" itemprop="referenced_product">
+    <span itemprop="prop2">PROP 2</span>
+    <img itemprop="image" src="img-2.jpg">
+  </div>
+  <div id="more-properties" itemscope itemtype="http://schema.org/Product">
+    <span itemprop="prop3">PROP 3</span>
+    <img itemprop="image" src="img-3.jpg">
+  </div>
+  <div id="related_products">
+    <div itemscope itemtype="http://schema.org/Product" itemprop="related_products">
+      <span itemprop="name">REL PROD 1</span>
+      <img itemprop="image" src="rel-prod-1.jpg">
+    </div>
+    <div itemscope itemtype="http://schema.org/Product" itemprop="related_products">
+      <span itemprop="name">REL PROD 2</span>
+      <img itemprop="image" src="rel-prod-2.jpg">
+    </div>
+   </div>
+ </body>
+</html>

--- a/tests/samples/schema.org/product-ref.html
+++ b/tests/samples/schema.org/product-ref.html
@@ -5,7 +5,7 @@
  </head>
  <body>
 
-  <div id="product" itemscope itemtype="http://schema.org/Product" itemref="other-product-properties more-properties related_products">
+  <div id="product" itemscope itemtype="http://schema.org/Product" itemref="referenced-product more-properties related_products non-existing-ref">
     <span itemprop="brand">ACME</span>
     <span itemprop="name">Executive Anvil</span>
     <img itemprop="image" src=" anvil_executive.jpg" alt="Executive Anvil logo"/>
@@ -33,13 +33,13 @@
       <link itemprop="availability" href="  http://schema.org/InStock"/>In stock! Order now!
     </span>
   </div>
-  <div id="other-product-properties" itemscope itemtype="http://schema.org/Product" itemprop="referenced_product">
-    <span itemprop="prop2">PROP 2</span>
-    <img itemprop="image" src="img-2.jpg">
+  <div id="referenced-product" itemscope itemtype="http://schema.org/Product" itemprop="referenced_product">
+    <span itemprop="name">REFERENCED PRODUCT</span>
+    <img itemprop="image" src="img-ref.jpg">
   </div>
   <div id="more-properties" itemscope itemtype="http://schema.org/Product">
-    <span itemprop="prop3">PROP 3</span>
-    <img itemprop="image" src="img-3.jpg">
+    <span itemprop="prop3">REFERENCED TO INCLUDE PROPERTIES AND ALSO INDIVIDUAL PRODUCT</span>
+    <img itemprop="image" src="img-2.jpg">
   </div>
   <div id="related_products">
     <div itemscope itemtype="http://schema.org/Product" itemprop="related_products">

--- a/tests/samples/schema.org/product-ref.json
+++ b/tests/samples/schema.org/product-ref.json
@@ -1,0 +1,71 @@
+[
+  {
+    "type": "http://schema.org/Product",
+    "properties": {
+      "referenced_product": {
+        "type": "http://schema.org/Product",
+        "properties": {
+          "prop2": "PROP 2",
+          "image": "img-2.jpg"
+        }
+      },
+      "prop2": "PROP 2",
+      "image": [
+        "img-2.jpg",
+        "img-3.jpg",
+        "anvil_executive.jpg"
+      ],
+      "prop3": "PROP 3",
+      "related_products": [
+        {
+          "type": "http://schema.org/Product",
+          "properties": {
+            "name": "REL PROD 1",
+            "image": "rel-prod-1.jpg"
+          }
+        },
+        {
+          "type": "http://schema.org/Product",
+          "properties": {
+            "name": "REL PROD 2",
+            "image": "rel-prod-2.jpg"
+          }
+        }
+      ],
+      "brand": "ACME",
+      "name": "Executive Anvil",
+      "description": "Sleeker than ACME's Classic Anvil, the\n      Executive Anvil is perfect for the business traveler\n      looking for something to drop from a height.",
+      "mpn": "925872",
+      "aggregateRating": {
+        "type": "http://schema.org/AggregateRating",
+        "properties": {
+          "ratingValue": "4.4",
+          "reviewCount": "89"
+        }
+      },
+      "offers": {
+        "type": "http://schema.org/Offer",
+        "properties": {
+          "priceCurrency": "USD",
+          "price": "119.99",
+          "priceValidUntil": "2020-11-05",
+          "seller": {
+            "type": "http://schema.org/Organization",
+            "properties": {
+              "name": "Executive Objects"
+            }
+          },
+          "itemCondition": "http://schema.org/UsedCondition",
+          "availability": "http://schema.org/InStock"
+        }
+      }
+    }
+  },
+  {
+    "type": "http://schema.org/Product",
+    "properties": {
+      "prop3": "PROP 3",
+      "image": "img-3.jpg"
+    }
+  }
+]

--- a/tests/samples/schema.org/product-ref.json
+++ b/tests/samples/schema.org/product-ref.json
@@ -1,71 +1,69 @@
 [
-  {
-    "type": "http://schema.org/Product",
-    "properties": {
-      "referenced_product": {
+    {
         "type": "http://schema.org/Product",
         "properties": {
-          "prop2": "PROP 2",
-          "image": "img-2.jpg"
-        }
-      },
-      "prop2": "PROP 2",
-      "image": [
-        "img-2.jpg",
-        "img-3.jpg",
-        "anvil_executive.jpg"
-      ],
-      "prop3": "PROP 3",
-      "related_products": [
-        {
-          "type": "http://schema.org/Product",
-          "properties": {
-            "name": "REL PROD 1",
-            "image": "rel-prod-1.jpg"
-          }
-        },
-        {
-          "type": "http://schema.org/Product",
-          "properties": {
-            "name": "REL PROD 2",
-            "image": "rel-prod-2.jpg"
-          }
-        }
-      ],
-      "brand": "ACME",
-      "name": "Executive Anvil",
-      "description": "Sleeker than ACME's Classic Anvil, the\n      Executive Anvil is perfect for the business traveler\n      looking for something to drop from a height.",
-      "mpn": "925872",
-      "aggregateRating": {
-        "type": "http://schema.org/AggregateRating",
-        "properties": {
-          "ratingValue": "4.4",
-          "reviewCount": "89"
-        }
-      },
-      "offers": {
-        "type": "http://schema.org/Offer",
-        "properties": {
-          "priceCurrency": "USD",
-          "price": "119.99",
-          "priceValidUntil": "2020-11-05",
-          "seller": {
-            "type": "http://schema.org/Organization",
-            "properties": {
-              "name": "Executive Objects"
+            "referenced_product": {
+                "type": "http://schema.org/Product",
+                "properties": {
+                    "name": "REFERENCED PRODUCT",
+                    "image": "img-ref.jpg"
+                }
+            },
+            "prop3": "REFERENCED TO INCLUDE PROPERTIES AND ALSO INDIVIDUAL PRODUCT",
+            "image": [
+                "img-2.jpg",
+                "anvil_executive.jpg"
+            ],
+            "related_products": [
+                {
+                    "type": "http://schema.org/Product",
+                    "properties": {
+                        "name": "REL PROD 1",
+                        "image": "rel-prod-1.jpg"
+                    }
+                },
+                {
+                    "type": "http://schema.org/Product",
+                    "properties": {
+                        "name": "REL PROD 2",
+                        "image": "rel-prod-2.jpg"
+                    }
+                }
+            ],
+            "brand": "ACME",
+            "name": "Executive Anvil",
+            "description": "Sleeker than ACME's Classic Anvil, the\n      Executive Anvil is perfect for the business traveler\n      looking for something to drop from a height.",
+            "mpn": "925872",
+            "aggregateRating": {
+                "type": "http://schema.org/AggregateRating",
+                "properties": {
+                    "ratingValue": "4.4",
+                    "reviewCount": "89"
+                }
+            },
+            "offers": {
+                "type": "http://schema.org/Offer",
+                "properties": {
+                    "priceCurrency": "USD",
+                    "price": "119.99",
+                    "priceValidUntil": "2020-11-05",
+                    "seller": {
+                        "type": "http://schema.org/Organization",
+                        "properties": {
+                            "name": "Executive Objects"
+                        }
+                    },
+                    "itemCondition": "http://schema.org/UsedCondition",
+                    "availability": "http://schema.org/InStock"
+                }
             }
-          },
-          "itemCondition": "http://schema.org/UsedCondition",
-          "availability": "http://schema.org/InStock"
         }
-      }
+    },
+    {
+        "type": "http://schema.org/Product",
+        "properties": {
+            "prop3": "REFERENCED TO INCLUDE PROPERTIES AND ALSO INDIVIDUAL PRODUCT",
+            "image": "img-2.jpg"
+        }
     }
-  },
-  {
-    "type": "http://schema.org/Product",
-    "properties": {
-      "prop3": "PROP 3",
-      "image": "img-3.jpg"
-    }
-  }
 ]

--- a/tests/samples/schema.org/product-ref.json
+++ b/tests/samples/schema.org/product-ref.json
@@ -11,8 +11,8 @@
             },
             "prop3": "REFERENCED TO INCLUDE PROPERTIES AND ALSO INDIVIDUAL PRODUCT",
             "image": [
-                "img-2.jpg",
-                "anvil_executive.jpg"
+                "anvil_executive.jpg",
+                "img-2.jpg"
             ],
             "related_products": [
                 {

--- a/tests/samples/w3c/microdata.5.3.json
+++ b/tests/samples/w3c/microdata.5.3.json
@@ -2,6 +2,6 @@
  {"properties": {"a": ["1", "2"], "b": ["test"]}},
  {"properties": {"a": ["1", "2"], "b": ["test"]}},
  {"properties": {"a": ["1", "2"], "b": ["test"]}},
- {"properties": {"a": ["1", "2"], "b": ["test"]}}
+ {"properties": {"a": ["2", "1"], "b": ["test"]}}
 ]
 

--- a/tests/test_microdata.py
+++ b/tests/test_microdata.py
@@ -183,5 +183,4 @@ class TestItemref(unittest.TestCase):
 
         mde = MicrodataExtractor()
         data = mde.extract(body)
-        print(json.dumps(data, indent=4))
         self.assertEqual(data, expected)

--- a/tests/test_microdata.py
+++ b/tests/test_microdata.py
@@ -171,3 +171,16 @@ class TestUrlJoin(unittest.TestCase):
         mde = MicrodataExtractor()
         data = mde.extract(body, base_url='http://some-example.com')
         self.assertEqual(data, expected)
+
+
+class TestItemref(unittest.TestCase):
+
+    maxDiff = None
+
+    def test_join_none(self):
+        body = get_testdata('schema.org', 'product-ref.html')
+        expected = json.loads(get_testdata('schema.org', 'product-ref.json').decode('UTF-8'))
+
+        mde = MicrodataExtractor()
+        data = mde.extract(body)
+        self.assertEqual(data, expected)

--- a/tests/test_microdata.py
+++ b/tests/test_microdata.py
@@ -183,4 +183,5 @@ class TestItemref(unittest.TestCase):
 
         mde = MicrodataExtractor()
         data = mde.extract(body)
+        print(json.dumps(data, indent=4))
         self.assertEqual(data, expected)


### PR DESCRIPTION
Extruct deals wrongly with elements referenced by `itemref` if the referenced element also include other items defined inside with `itemscope`. For example:
```html
<html>
<body>
<div id="product" itemscope itemtype="http://schema.org/Product" itemref="other-product-properties">
    <span itemprop="name">Executive Anvil</span>
    <img itemprop="image" src="img1.jpg"/>
</div>
<div id="other-product-properties">
    <img itemprop="image" src="img2.jpg"/>
    <div itemscope itemtype="http://schema.org/Product" itemprop="related_products">
        <span itemprop="name">REL PROD 1</span>
        <img itemprop="image" src="rel-prod-1.jpg">
    </div>
</div>
</body>
</html>
```

Is extracted as (see the duplicate name and the extra image):

```py
[{'@context': 'http://schema.org',
  '@type': 'Product',
  'image': ['img2.jpg', 'rel-prod-1.jpg', 'img1.jpg'],
  'name': ['REL PROD 1', 'Executive Anvil'],
  'related_products': {'@type': 'Product',
                       'image': 'rel-prod-1.jpg',
                       'name': 'REL PROD 1'}}]
```
This PR patchs the code to solve this problem, so that the extracted result is:

```py
[{'@context': 'http://schema.org',
  '@type': 'Product',
  'image': ['img2.jpg', 'img1.jpg'],
  'name': 'Executive Anvil',
  'related_products': {'@type': 'Product',
                       'image': 'rel-prod-1.jpg',
                       'name': 'REL PROD 1'}}]
```
I patched function `_extract_property_refs()` so that properties in a different scope than the referenced element are skipped. I have passed the tests and they pass.