### PR TITLE
[wip] use html_text to get element text content in microdata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ rdflib-jsonld
 mf2py>=1.1.0
 six
 w3lib
+html-text

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
                       'rdflib-jsonld', 
                       'mf2py', 
                       'w3lib',
+                      'html-text>=0.5.1',
                       'six'],
     extras_require={
         'service': [


### PR DESCRIPTION
This is an unfinished fix for https://github.com/scrapinghub/extruct/issues/113, please don't merge. I've opened the PR just to share initial code. It has these problems:

* cleaning can be too aggressive, e.g. `<style>` elements are removed. This may cause missing extractions, if microdata is set on these elements.
* tests are failing (I haven't looked at them - probably the fix is not correct at all :)

The problem with not cleaning HTML tree once is that it could make algorithm O(N^2) - but maybe that's fine.