### PR TITLE
Reverse priorities for repeated properties in uniform format for opengraph

### DIFF
--- a/extruct/uniform.py
+++ b/extruct/uniform.py
@@ -4,7 +4,7 @@ from six.moves.urllib.parse import urlparse, urljoin
 def _uopengraph(extracted):
     out = []
     for obj in extracted:
-        flattened = dict(obj['properties'])
+        flattened = dict(reversed(obj['properties']))
         t = flattened.pop('og:type', None)
         if t:
             flattened['@type'] = t

--- a/tests/samples/songkick/elysianfields.html
+++ b/tests/samples/songkick/elysianfields.html
@@ -30,6 +30,7 @@
     <meta property="og:description" content="Buy tickets for an upcoming Elysian Fields concert near you. List of all Elysian Fields tickets and tour dates for 2017.">
     <meta property="og:url" content="http://www.songkick.com/artists/236156-elysian-fields">
     <meta property="og:image" content="http://images.sk-static.com/images/media/img/col4/20100330-103600-169450.jpg">
+    <meta property="og:image" content="http://images.sk-static.com/SECONDARY_IMAGE.jpg">
   </head>
   <body>
     <script>

--- a/tests/samples/songkick/elysianfields.json
+++ b/tests/samples/songkick/elysianfields.json
@@ -202,6 +202,10 @@
                 [
                     "og:image",
                     "http://images.sk-static.com/images/media/img/col4/20100330-103600-169450.jpg"
+                ],
+                [
+                    "og:image",
+                    "http://images.sk-static.com/SECONDARY_IMAGE.jpg"
                 ]
             ]
         }
@@ -233,6 +237,9 @@
             "http://ogp.me/ns#image": [
                 {
                     "@value": "http://images.sk-static.com/images/media/img/col4/20100330-103600-169450.jpg"
+                },
+                {
+                    "@value": "http://images.sk-static.com/SECONDARY_IMAGE.jpg"
                 }
             ],
             "http://ogp.me/ns#site_name": [

--- a/tests/test_extruct.py
+++ b/tests/test_extruct.py
@@ -5,6 +5,7 @@ import unittest
 import pytest
 
 import extruct
+from extruct import SYNTAXES
 from tests import get_testdata, jsonize_dict, replace_node_ref_with_node_id
 
 
@@ -16,6 +17,21 @@ class TestGeneric(unittest.TestCase):
         body = get_testdata('songkick', 'elysianfields.html')
         expected = json.loads(get_testdata('songkick', 'elysianfields.json').decode('UTF-8'))
         data = extruct.extract(body, base_url='http://www.songkick.com/artists/236156-elysian-fields')
+        # See test_rdfa_not_preserving_order()
+        del data['rdfa'][0]['http://ogp.me/ns#image']
+        del expected['rdfa'][0]['http://ogp.me/ns#image']
+        self.assertEqual(jsonize_dict(data), expected)
+
+    @pytest.mark.xfail
+    def test_rdfa_not_preserving_order(self):
+        # See https://github.com/scrapinghub/extruct/issues/116
+        # RDFa is not preserving ordering on duplicated properties. So this
+        # test sometimes fails for property 'http://ogp.me/ns#image'
+        body = get_testdata('songkick', 'elysianfields.html')
+        expected = json.loads(get_testdata('songkick', 'elysianfields.json').decode('UTF-8'))
+        data = extruct.extract(body,
+                               base_url='http://www.songkick.com/artists/236156-elysian-fields',
+                               syntaxes=['rdfa'])
         self.assertEqual(jsonize_dict(data), expected)
 
     def test_microdata_custom_url(self):

--- a/tests/test_uniform.py
+++ b/tests/test_uniform.py
@@ -1,7 +1,7 @@
 import unittest
 
 import extruct
-from extruct.uniform import _flatten, infer_context, flatten_dict
+from extruct.uniform import _flatten, infer_context, flatten_dict, _uopengraph
 from tests import get_testdata
 
 
@@ -26,6 +26,16 @@ class TestUniform(unittest.TestCase):
         body = get_testdata('songkick', 'elysianfields.html')
         data = extruct.extract(body, syntaxes=['opengraph'], uniform=True)
         self.assertEqual(data['opengraph'], expected)
+
+    def test_uopengraph_duplicated_priorities(self):
+        # Ensures that first seen property is kept when flattening
+        data = _uopengraph([{'properties':
+                                 [(f'prop_{k}', f'value_{v}')
+                                  for k in range(5)
+                                  for v in range(5)],
+                             'namespace': 'namespace'}])
+        for k in range(5):
+            assert data[0][f'prop_{k}'] == 'value_0'
 
     def test_umicroformat(self):
         expected = [ { '@context': 'http://microformats.org/wiki/',

--- a/tests/test_uniform.py
+++ b/tests/test_uniform.py
@@ -30,12 +30,12 @@ class TestUniform(unittest.TestCase):
     def test_uopengraph_duplicated_priorities(self):
         # Ensures that first seen property is kept when flattening
         data = _uopengraph([{'properties':
-                                 [(f'prop_{k}', f'value_{v}')
+                                 [('prop_{}'.format(k), 'value_{}'.format(v))
                                   for k in range(5)
                                   for v in range(5)],
                              'namespace': 'namespace'}])
         for k in range(5):
-            assert data[0][f'prop_{k}'] == 'value_0'
+            assert data[0]['prop_{}'.format(k)] == 'value_0'
 
     def test_umicroformat(self):
         expected = [ { '@context': 'http://microformats.org/wiki/',


### PR DESCRIPTION
Some pages contain a duplicated definition of some properties like "og:image". See the following pages:
https://nerdist.com/article/star-wars-cast-reylo-episode-ix/
https://cleantechnica.com/2019/04/16/fukushimas-final-costs-will-approach-one-trillion-dollars-just-for-nuclear-disaster/

Extruct default behaviour seems to be keep the last one, meanwhile Facebook default behaviour seems to be keep the first one according to results at the developer tool (see https://developers.facebook.com/tools/debug/sharing/?q=https%3A%2F%2Fnerdist.com%2Farticle%2Fstar-wars-cast-reylo-episode-ix%2F for an example).

Extruct should mimic Facebook behaviour so this PR is reverting the priorities when flattening OpenGraph properties.