### PR TITLE
drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
recent lxml doesn't work with Python 3.4, and Python 3.4 is unsupported.

Tests are failing in Python 3.4 because recent lxml can't be installed.