### PR TITLE
[WIP] Extract opengraph from body as well

### DIFF
--- a/extruct/opengraph.py
+++ b/extruct/opengraph.py
@@ -23,13 +23,13 @@ class OpenGraphExtractor(object):
 
     def extract_items(self, document, base_url=None):
         # OpenGraph defines a web page as a single rich object.
-        for head in document.xpath('//head'):
+        for root in document.xpath('//head') + document.xpath('//body'):
             html_elems = document.head.xpath("parent::html")
             namespaces = self.get_namespaces(
                 html_elems[0]) if html_elems else {}
-            namespaces.update(self.get_namespaces(head))
+            namespaces.update(self.get_namespaces(root))
             props = []
-            for el in head.xpath('meta[@property and @content]'):
+            for el in root.xpath('meta[@property and @content]'):
                 prop = el.attrib['property']
                 val = el.attrib['content']
                 ns = prop.partition(':')[0]


### PR DESCRIPTION
Normally opengraph ``<meta property=".." content="..">`` tags are in the head, but having them in the body is also surprisingly common - in our internal article dataset they are present in body on 5% of all pages (out of all pages with such tags anywhere on the page), and on 12% for products.

One such example is https://www.reuters.com/article/us-health-coronavirus-apple/coronavirus-case-at-apples-irish-hq-trinity-college-goes-online-idUSKBN20X1QT - so it's even on  a popular website.

TODO:
- [ ] add tests
- [ ] double-check what is happening with namespaces