### PR TITLE
feat: add parser for JSON with JS comment

### DIFF
--- a/extruct/jsonld.py
+++ b/extruct/jsonld.py
@@ -11,6 +11,7 @@ import lxml.etree
 
 from extruct.utils import parse_html
 
+HTML_OR_JS_COMMENTLINE = re.compile(r'^\s*(//.*|<!--.*-->)')
 
 
 class JsonLdExtractor(object):
@@ -34,7 +35,7 @@ class JsonLdExtractor(object):
             data = json.loads(script, strict=False)
         except ValueError:
             # sometimes JSON-decoding errors are due to leading HTML or JavaScript comments
-            data = jstyleson.loads(script, strict=False)
+            data = jstyleson.loads(HTML_OR_JS_COMMENTLINE.sub('', script),strict=False)
         if isinstance(data, list):
             return data
         elif isinstance(data, dict):

--- a/extruct/jsonld.py
+++ b/extruct/jsonld.py
@@ -10,7 +10,6 @@ import lxml.etree
 
 from extruct.utils import parse_html
 
-HTML_OR_JS_COMMENTLINE = re.compile(r'^\s*(//.*|<!--.*-->)')
 
 
 class JsonLdExtractor(object):
@@ -34,8 +33,7 @@ class JsonLdExtractor(object):
             data = json.loads(script, strict=False)
         except ValueError:
             # sometimes JSON-decoding errors are due to leading HTML or JavaScript comments
-            data = jstyleson.loads(
-                HTML_OR_JS_COMMENTLINE.sub('', script), strict=False)
+            data = jstyleson.loads(script, strict=False)
         if isinstance(data, list):
             return data
         elif isinstance(data, dict):

--- a/extruct/jsonld.py
+++ b/extruct/jsonld.py
@@ -2,9 +2,10 @@
 """
 JSON-LD extractor
 """
-import jstyleson
 import json
 import re
+import jstyleson
+
 
 import lxml.etree
 

--- a/extruct/jsonld.py
+++ b/extruct/jsonld.py
@@ -2,7 +2,7 @@
 """
 JSON-LD extractor
 """
-
+import jstyleson
 import json
 import re
 
@@ -34,7 +34,7 @@ class JsonLdExtractor(object):
             data = json.loads(script, strict=False)
         except ValueError:
             # sometimes JSON-decoding errors are due to leading HTML or JavaScript comments
-            data = json.loads(
+            data = jstyleson.loads(
                 HTML_OR_JS_COMMENTLINE.sub('', script), strict=False)
         if isinstance(data, list):
             return data

--- a/extruct/jsonld.py
+++ b/extruct/jsonld.py
@@ -2,6 +2,7 @@
 """
 JSON-LD extractor
 """
+
 import json
 import re
 

--- a/extruct/jsonld.py
+++ b/extruct/jsonld.py
@@ -4,9 +4,8 @@ JSON-LD extractor
 """
 import json
 import re
+
 import jstyleson
-
-
 import lxml.etree
 
 from extruct.utils import parse_html

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ mf2py>=1.1.0
 six>=1.11
 w3lib
 html-text
+jstyleson

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,9 @@ setup(
                       'mf2py',
                       'w3lib',
                       'html-text>=0.5.1',
-                      'six'],
+                      'six',
+                      'jstyleson'
+                      ],
     extras_require={
         'cli': [
             'requests',

--- a/tests/samples/custom.invalid/JSONLD_with_JS_comment.html
+++ b/tests/samples/custom.invalid/JSONLD_with_JS_comment.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <script type="application/ld+json">
+
+	{
+		"@context": "http://schema.org",
+		"@type": "NewsArticle",
+		"thumbnailUrl": "https://uc.udn.com.tw/photo/2019/11/11/99/7053890.jpg",
+		"keywords": "",
+		"url": "https://money.udn.com/money/story/5635/4158094",
+		"mainEntityOfPage": "https://money.udn.com/money/story/5635/4158094",
+		"headline": "讓AI挑出感興趣 SparkAmplify精準行銷當紅",
+		"articleSection": "商情", // category
+		//"interactionCount": ""
+	}
+		
+    </script>
+</head>
+
+<body></body>
+
+</html>

--- a/tests/samples/custom.invalid/JSONLD_with_JS_comment.jsonld
+++ b/tests/samples/custom.invalid/JSONLD_with_JS_comment.jsonld
@@ -1,0 +1,12 @@
+[
+	{
+		"@context": "http://schema.org",
+		"@type": "NewsArticle",
+		"thumbnailUrl": "https://uc.udn.com.tw/photo/2019/11/11/99/7053890.jpg",
+		"keywords": "",
+		"url": "https://money.udn.com/money/story/5635/4158094",
+		"mainEntityOfPage": "https://money.udn.com/money/story/5635/4158094",
+		"headline": "讓AI挑出感興趣 SparkAmplify精準行銷當紅",
+		"articleSection": "商情"
+	}
+]

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -40,6 +40,11 @@ class TestJsonLD(unittest.TestCase):
         self.assertJsonLdCorrect(
             folder='custom.invalid',
             page='JSONLD_with_control_characters_comment')
+        
+    def test_jsonld_with_json_including_js_comment(self):
+        self.assertJsonLdCorrect(
+            folder='custom.invalid',
+            page='JSONLD_with_JS_comment')
 
     def assertJsonLdCorrect(self, folder, page):
         body, expected = self._get_body_expected(folder, page)


### PR DESCRIPTION
I encountered the issue of parsing `json-ld` with JS comments. Finally, I found the `jstyleson` package that could solve.

### Reproduce issue:
```
1. comment the key-value pair 
2. comment occurs after the key-value pair 

{
 '\t//"interactionCount": "", // 文章互動數 \r\n'
'\t\t"height": "1000", // 高度， 有預設或是的高度\r\n'
}
```
