### PR TITLE
Remove an ugly way to pass python version to tox

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,4 +30,4 @@ jobs:
         python -m pip install -r requirements-dev.txt
     - name: tox
       run: |
-        tox -e `python -c "import sys; print('py' + ''.join(sys.version.split('.')[:2]))"`
+        tox -e py


### PR DESCRIPTION
https://tox.readthedocs.io/en/latest/example/basic.html#a-simple-tox-ini-default-environments - as suggested by @kmike here https://github.com/scrapinghub/extruct/pull/164#discussion_r541546548