### PR TITLE
Fix README, make sure it renders

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -680,7 +680,7 @@ extract the metadata from it directly from the command line.
 Dependencies
 ++++++++++++
 
-The command line tool depends on requests_, which is not installed by default
+The command line tool depends on ``requests``, which is not installed by default
 when you install **extruct**. In order to use the command line tool, you can
 install **extruct** with the `cli` extra requirements::
 
@@ -735,3 +735,4 @@ Use tox_ to run tests with different Python versions::
 
 
 .. _tox: https://testrun.org/tox/latest/
+.. _ogp: https://ogp.me/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,9 +3,10 @@
 
 -r requirements.txt
 
-pytest
 tox
-flake8
-readme_renderer
-
 bumpversion
+
+pytest
+pytest-cov
+readme_renderer
+mock

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,6 @@
 pytest
 tox
 flake8
+readme_renderer
 
 bumpversion

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,7 @@ envlist = py27, py35, py36, py37, py38, py39
 
 [testenv]
 deps =
-    -rrequirements.txt
-    pytest
-    pytest-cov
-    mock
+    -rrequirements-dev.txt
 
 commands = py.test --cov-report=term --cov-report= --cov=extruct {posargs:extruct tests}
            python -m readme_renderer README.rst -o /tmp/README.html

--- a/tox.ini
+++ b/tox.ini
@@ -9,3 +9,4 @@ deps =
     mock
 
 commands = py.test --cov-report=term --cov-report= --cov=extruct {posargs:extruct tests}
+           python -m readme_renderer README.rst -o /tmp/README.html

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,15 @@
 [tox]
 envlist = py27, py35, py36, py37, py38, py39
 
+
 [testenv]
 deps =
     -rrequirements-dev.txt
+commands =
+    py.test --cov-report=term --cov-report= --cov=extruct {posargs:extruct tests}
 
-commands = py.test --cov-report=term --cov-report= --cov=extruct {posargs:extruct tests}
-           python -m readme_renderer README.rst -o /tmp/README.html
+
+[testenv:py38]
+commands =
+    py.test --cov-report=term --cov-report= --cov=extruct {posargs:extruct tests}
+    python -m readme_renderer README.rst -o /tmp/README.html


### PR DESCRIPTION
If it does not render, we won't be able to publish a release on PyPI, see https://github.com/scrapinghub/extruct/pull/168#issuecomment-751741909