### PR TITLE
Check for type when extracting RDFa content

### DIFF
--- a/extruct/rdfa.py
+++ b/extruct/rdfa.py
@@ -151,7 +151,11 @@ class RDFaExtractor(object):
                           refresh_vocab_cache=False,
                           check_lite=False)
         g = PyRdfa(options, base=base_url).graph_from_DOM(document, graph=Graph(), pgraph=Graph())
-        jsonld_string = g.serialize(format='json-ld', auto_compact=not expanded).decode('utf-8')
+        jsonld_string = g.serialize(format='json-ld', auto_compact=not expanded)
+
+        # rdflib may return either bytes or strings
+        if isinstance(jsonld_string, bytes):
+            jsonld_string = jsonld_string.decode('utf-8')
         
         try:
             # hack to fix the ordering of multi-value properties (see issue 116)


### PR DESCRIPTION
This PR aims to close #176, where it's described how the latest `rdflib` dependency may not always return bytes, thus fresh installations would raise errors.

The changes here aim to be backward compatible with older versions of `rdflib`.  

This was tested as follows:

1) Setup this package
2) Install rdflib 6.0.0: `pip install rdflib==6.0.0`
3) run the test and see them failing: (truncated to only failing tests)
```python
cydanil@inara ~/extruct> pytest -vv tests                                                                                                                                                                                master
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.9.1, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/cydanil/gourmand/venv/bin/python
cachedir: .pytest_cache
rootdir: /home/cydanil/extruct, configfile: pytest.ini
collected 69 items                                                                                                                                                                                                                           


tests/test_extruct.py::TestGeneric::test_all FAILED                                                                                                                                                                                    [  2%]
tests/test_extruct.py::TestGeneric::test_rdfa_is_preserving_order FAILED                                                                                                                                                               [ 11%]
tests/test_extruct_uniform.py::TestFlatten::test_microdata FAILED                                                                                                                                                                      [ 13%]
tests/test_extruct_uniform.py::TestFlatten::test_microdata_with_returning_node FAILED                                                                                                                                                  [ 14%]
tests/test_extruct_uniform.py::TestFlatten::test_microformat FAILED                                                                                                                                                                    [ 15%]
tests/test_extruct_uniform.py::TestFlatten::test_opengraph FAILED                                                                                                                                                                      [ 17%]
tests/test_rdfa.py::TestRDFa::test_expanded_opengraph_support FAILED                                                                                                                                                                   [ 63%]
tests/test_rdfa.py::TestRDFa::test_w3c_rdf11primer FAILED                                                                                                                                                                              [ 65%]
tests/test_rdfa.py::TestRDFa::test_w3c_rdfalite FAILED                                                                                                                                                                                 [ 66%]
tests/test_rdfa.py::TestRDFa::test_w3c_rdfaprimer FAILED                                                                                                                                                                               [ 68%]
tests/test_rdfa.py::TestRDFa::test_wikipedia_xhtml_rdfa FAILED                                                                                                                                                                         [ 69%]
tests/test_rdfa.py::TestRDFa::test_wikipedia_xhtml_rdfa_no_prefix FAILED                                                                                                                                                               [ 71%]
tests/test_tool.py::TestTool::test_main_all FAILED                                                                                                                                                                                     [ 72%]
tests/test_tool.py::TestTool::test_main_multiple_syntaxes PASSED                                                                                                                                                                       [ 73%]
tests/test_tool.py::TestTool::test_metadata_from_url_all_types FAILED                                                                                                                                                                  [ 76%]
tests/test_tool.py::TestTool::test_metadata_from_url_rdfa_only FAILED                                                                                                                                                                  [ 84%]
```

4) Applying the proposed changes and see all tests pass.  

5) Downgrading rdflib to 5.0.0 (`pip install rdflib==5.0.0`) and seeing all tests pass as well.

Thank you!