### PR TITLE
Fix linguist stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-tests/samples/* linguist-vendored
+tests/samples/** linguist-vendored


### PR DESCRIPTION
The current project stats show that it is mostly HTML due to an incorrectly set `.gitattributes`. This pull request fixes this.