### PR TITLE
Removed rdflib-jsonld as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,9 @@
 # pip install -r requirements.txt
 lxml
 requests
-rdflib>=6.0.1
+rdflib>=6.0.1; python_version>="3.7"
+rdflib<6.0.0; python_version<"3.7"
+rdflib-jsonld<=0.5.0; python_version<"3.7"
 pyrdfa3
 mf2py>=1.1.0
 six>=1.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@
 # pip install -r requirements.txt
 lxml
 requests
-rdflib
-rdflib-jsonld
+rdflib>=6.0.1
 pyrdfa3
 mf2py>=1.1.0
 six>=1.11

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,10 @@ setup(
     packages=find_packages(exclude=['tests',]),
     package_data={'extruct': ['VERSION']},
     install_requires=['lxml',
-                      'rdflib',
-                      'rdflib-jsonld',
+                      'rdflib<6.0.0;python_version<"3.7"',
+                      'rdflib-jsonld;python_version<"3.7"',
+                      # rdflib 6.x.y (only on 3.7 and up) contains jsonld
+                      'rdflib>=6.0.1;python_version>="3.7"',
                       'pyrdfa3',
                       'mf2py',
                       'w3lib',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     package_data={'extruct': ['VERSION']},
     install_requires=['lxml',
                       'rdflib<6.0.0;python_version<"3.7"',
-                      'rdflib-jsonld;python_version<"3.7"',
+                      'rdflib-jsonld<=0.5.0;python_version<"3.7"',
                       # rdflib 6.x.y (only on 3.7 and up) contains jsonld
                       'rdflib>=6.0.1;python_version>="3.7"',
                       'pyrdfa3',


### PR DESCRIPTION
As of yesterday's rdflib 6.0.1 release, the [rdflib-jsonld dependency](https://github.com/RDFLib/rdflib-jsonld/blob/master/README.md#archived) is now a part of rdflib proper.  This PR just removes it from the requirements.

Tests run fine on my machine (python 3.8.3, Ubuntu), let me know if there's any else I can do to help merge. 