### PR TITLE
create .git-blame-ignore-revs to contain commits due to black and isort

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Contains commits to be ignored due to linting
+
+# https://github.com/scrapinghub/extruct/pull/201
+c52cdf2a0caaeaaa0bee978b9d06451c93b7e8be
+f6c235fa8a7513f21cb3381bfa429674cc566781
+f2fc2231706905de1b818fae2040ef61ed2c4418


### PR DESCRIPTION
Follow-up on https://github.com/scrapinghub/extruct/pull/201