### PR TITLE
Allow receiving an external tree, drop python 3.7

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -216,6 +216,15 @@ It is possible to select which syntaxes to extract by passing a list with the de
                 'http://ogp.me/ns#url': [ { '@value': 'https://www.songkick.com/artists/236156-elysian-fields'}],
                 'http://www.facebook.com/2008/fbmlapp_id': [ { '@value': '308540029359'}]}]}
 
+Alternatively, if you already parsed the HTML before calling extruct, you can use the tree instead of the HTML string: ::
+
+  >>> # using the request from the previous example
+  >>> base_url = get_base_url(r.text, r.url)
+  >>> from extruct.utils import parse_html
+  >>> tree = parse_html(r.text)
+  >>> data = extruct.extract(tree, base_url, syntaxes=['microdata', 'opengraph', 'rdfa'])
+
+Microformat format doesn't support the HTML tree, so you need to use a HTML string.
 
 Uniform
 +++++++
@@ -264,7 +273,7 @@ To do so set ``uniform=True`` when calling ``extract``, it's false by default fo
                 'http://ogp.me/ns#url': [ { '@value': 'https://www.songkick.com/artists/236156-elysian-fields'}],
                 'http://www.facebook.com/2008/fbmlapp_id': [ { '@value': '308540029359'}]}]}
 
-NB rdfa structure is not uniformed yet
+NB rdfa structure is not uniformed yet.
 
 Returning HTML node
 +++++++++++++++++++

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,9 @@ setup(
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/tests/test_extruct.py
+++ b/tests/test_extruct.py
@@ -6,7 +6,7 @@ import unittest
 import pytest
 
 import extruct
-from extruct import SYNTAXES
+from extruct.utils import parse_html
 from tests import get_testdata, jsonize_dict, replace_node_ref_with_node_id
 
 
@@ -38,8 +38,9 @@ class TestGeneric(unittest.TestCase):
 
     def test_microdata_custom_url(self):
         body, expected = self._microdata_custom_url("product_custom_url.json")
+        tree = parse_html(body, encoding="UTF-8")
         data = extruct.extract(
-            body, base_url="http://some-example.com", syntaxes=["microdata"]
+            tree, base_url="http://some-example.com", syntaxes=["microdata"]
         )
         self.assertEqual(data, expected)
 
@@ -65,7 +66,7 @@ class TestGeneric(unittest.TestCase):
         self.assertEqual(data, expected)
 
     def test_extra_kwargs(self):
-        body, expected = self._microdata_custom_url("product_custom_url.json")
+        body, _ = self._microdata_custom_url("product_custom_url.json")
         with self.assertRaises(TypeError):
             extruct.extract(body, foo="bar")  # type: ignore[call-arg]
 

--- a/tests/test_extruct.py
+++ b/tests/test_extruct.py
@@ -83,7 +83,7 @@ class TestGeneric(unittest.TestCase):
         body = ""
 
         # raise exceptions
-        with pytest.raises(Exception):
+        with self.assertRaises(Exception):
             data = extruct.extract(body)
 
         # ignore exceptions

--- a/tests/test_extruct_uniform.py
+++ b/tests/test_extruct_uniform.py
@@ -13,27 +13,50 @@ class TestFlatten(unittest.TestCase):
     maxDiff = None
 
     def test_microdata(self):
-        body = get_testdata("schema.org", "CreativeWork.001.html")
-        tree = parse_html(body, encoding="UTF-8")
-        expected = json.loads(
-            get_testdata("schema.org", "CreativeWork_flat.001.json").decode("UTF-8")
+        body, tree, expected = self._testdata_html_and_tree(
+            "schema.org",
+            "CreativeWork.001.html",
+            "CreativeWork_flat.001.json",
+
         )
-        data = extruct.extract(tree, uniform=True, syntaxes=["microdata"])
-        self.assertEqual(jsonize_dict(data["microdata"]), expected["microdata"])
+        syntax = "microdata"
+        data = extruct.extract(body, uniform=True, syntaxes=[syntax])
+        self.assertEqual(jsonize_dict(data[syntax]), expected[syntax])
+
+        data = extruct.extract(tree, uniform=True, syntaxes=[syntax])
+        self.assertEqual(jsonize_dict(data[syntax]), expected[syntax])
+
+    def test_opengraph(self):
+        body, tree, expected = self._testdata_html_and_tree(
+            "misc",
+            "opengraph_test.html",
+            "opengraph_flat_test.json",
+        )
+        syntax = "opengraph"
+        data = extruct.extract(body, uniform=True, syntaxes=[syntax])
+        self.assertEqual(jsonize_dict(data[syntax]), expected)
+
+        data = extruct.extract(tree, uniform=True, syntaxes=[syntax])
+        self.assertEqual(jsonize_dict(data[syntax]), expected)
 
     def test_microdata_with_returning_node(self):
-        body = get_testdata("schema.org", "CreativeWork.001.html")
-        tree = parse_html(body, encoding="UTF-8")
-        expected = json.loads(
-            get_testdata(
-                "schema.org", "CreativeWork_flat_with_node_id.001.json"
-            ).decode("UTF-8")
+        body, tree, expected = self._testdata_html_and_tree(
+            "schema.org",
+            "CreativeWork.001.html",
+            "CreativeWork_flat_with_node_id.001.json",
         )
+        syntax = "microdata"
         data = extruct.extract(
-            tree, uniform=True, return_html_node=True, syntaxes=["microdata"]
+            body, uniform=True, return_html_node=True, syntaxes=[syntax]
         )
-        replace_node_ref_with_node_id(data["microdata"])
-        self.assertEqual(jsonize_dict(data["microdata"]), expected["microdata"])
+        replace_node_ref_with_node_id(data[syntax])
+        self.assertEqual(jsonize_dict(data[syntax]), expected[syntax])
+
+        data = extruct.extract(
+            tree, uniform=True, return_html_node=True, syntaxes=[syntax]
+        )
+        replace_node_ref_with_node_id(data[syntax])
+        self.assertEqual(jsonize_dict(data[syntax]), expected[syntax])
 
     def test_microformat(self):
         body = get_testdata("misc", "microformat_test.html")
@@ -43,10 +66,8 @@ class TestFlatten(unittest.TestCase):
         data = extruct.extract(body, uniform=True, syntaxes=["microformat"])
         self.assertEqual(jsonize_dict(data["microformat"]), expected)
 
-    def test_opengraph(self):
-        body = get_testdata("misc", "opengraph_test.html")
-        expected = json.loads(
-            get_testdata("misc", "opengraph_flat_test.json").decode("UTF-8")
-        )
-        data = extruct.extract(body, uniform=True, syntaxes=["opengraph"])
-        self.assertEqual(jsonize_dict(data["opengraph"]), expected)
+    def _testdata_html_and_tree(self, root, path1, path2):
+        body = get_testdata(root, path1)
+        tree = parse_html(body, encoding="UTF-8")
+        expected = json.loads(get_testdata(root, path2).decode("UTF-8"))
+        return body, tree, expected

--- a/tests/test_extruct_uniform.py
+++ b/tests/test_extruct_uniform.py
@@ -17,7 +17,6 @@ class TestFlatten(unittest.TestCase):
             "schema.org",
             "CreativeWork.001.html",
             "CreativeWork_flat.001.json",
-
         )
         syntax = "microdata"
         data = extruct.extract(body, uniform=True, syntaxes=[syntax])

--- a/tests/test_extruct_uniform.py
+++ b/tests/test_extruct_uniform.py
@@ -4,6 +4,7 @@ import json
 import unittest
 
 import extruct
+from extruct.utils import parse_html
 from tests import get_testdata, jsonize_dict, replace_node_ref_with_node_id
 
 
@@ -13,21 +14,23 @@ class TestFlatten(unittest.TestCase):
 
     def test_microdata(self):
         body = get_testdata("schema.org", "CreativeWork.001.html")
+        tree = parse_html(body, encoding="UTF-8")
         expected = json.loads(
             get_testdata("schema.org", "CreativeWork_flat.001.json").decode("UTF-8")
         )
-        data = extruct.extract(body, uniform=True, syntaxes=["microdata"])
+        data = extruct.extract(tree, uniform=True, syntaxes=["microdata"])
         self.assertEqual(jsonize_dict(data["microdata"]), expected["microdata"])
 
     def test_microdata_with_returning_node(self):
         body = get_testdata("schema.org", "CreativeWork.001.html")
+        tree = parse_html(body, encoding="UTF-8")
         expected = json.loads(
             get_testdata(
                 "schema.org", "CreativeWork_flat_with_node_id.001.json"
             ).decode("UTF-8")
         )
         data = extruct.extract(
-            body, uniform=True, return_html_node=True, syntaxes=["microdata"]
+            tree, uniform=True, return_html_node=True, syntaxes=["microdata"]
         )
         replace_node_ref_with_node_id(data["microdata"])
         self.assertEqual(jsonize_dict(data["microdata"]), expected["microdata"])

--- a/tests/test_extruct_uniform.py
+++ b/tests/test_extruct_uniform.py
@@ -16,7 +16,7 @@ class TestFlatten(unittest.TestCase):
         expected = json.loads(
             get_testdata("schema.org", "CreativeWork_flat.001.json").decode("UTF-8")
         )
-        data = extruct.extract(body, uniform=True)
+        data = extruct.extract(body, uniform=True, syntaxes=["microdata"])
         self.assertEqual(jsonize_dict(data["microdata"]), expected["microdata"])
 
     def test_microdata_with_returning_node(self):
@@ -26,7 +26,9 @@ class TestFlatten(unittest.TestCase):
                 "schema.org", "CreativeWork_flat_with_node_id.001.json"
             ).decode("UTF-8")
         )
-        data = extruct.extract(body, uniform=True, return_html_node=True)
+        data = extruct.extract(
+            body, uniform=True, return_html_node=True, syntaxes=["microdata"]
+        )
         replace_node_ref_with_node_id(data["microdata"])
         self.assertEqual(jsonize_dict(data["microdata"]), expected["microdata"])
 
@@ -35,7 +37,7 @@ class TestFlatten(unittest.TestCase):
         expected = json.loads(
             get_testdata("misc", "microformat_flat_test.json").decode("UTF-8")
         )
-        data = extruct.extract(body, uniform=True)
+        data = extruct.extract(body, uniform=True, syntaxes=["microformat"])
         self.assertEqual(jsonize_dict(data["microformat"]), expected)
 
     def test_opengraph(self):
@@ -43,5 +45,5 @@ class TestFlatten(unittest.TestCase):
         expected = json.loads(
             get_testdata("misc", "opengraph_flat_test.json").decode("UTF-8")
         )
-        data = extruct.extract(body, uniform=True)
+        data = extruct.extract(body, uniform=True, syntaxes=["opengraph"])
         self.assertEqual(jsonize_dict(data["opengraph"]), expected)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39
+envlist = py38, py39, py310
 
 
 [testenv]
@@ -8,7 +8,7 @@ deps =
 commands =
     py.test --cov-report=term --cov-report= --cov=extruct {posargs:extruct tests}
 
-[testenv:py38]
+[testenv:py39]
 commands =
     py.test --cov-report=term --cov-report= --cov=extruct {posargs:extruct tests}
     python -m readme_renderer README.rst -o /tmp/README.html

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py39, py310
+envlist = py38, py39, py310, py311
 
 
 [testenv]


### PR DESCRIPTION
A small performance improvement: allow receiving an external tree into extruct.
Also bump the default Python version to 3.9, hope that's OK.