### PR TITLE
Fix SyntaxWarning in #213

### DIFF
--- a/extruct/rdfa.py
+++ b/extruct/rdfa.py
@@ -85,7 +85,7 @@ class RDFaExtractor:
 
         match = None
         if head_element.get("prefix"):
-            match = re.search(prefix + ": [^\\s]+", head_element.get("prefix"))
+            match = re.search(prefix + r": [^\s]+", head_element.get("prefix"))
 
         # if namespace taken from prefix attribute in head tag
         if match:

--- a/extruct/rdfa.py
+++ b/extruct/rdfa.py
@@ -85,7 +85,7 @@ class RDFaExtractor:
 
         match = None
         if head_element.get("prefix"):
-            match = re.search(prefix + ": [^\s]+", head_element.get("prefix"))
+            match = re.search(prefix + ": [^\\s]+", head_element.get("prefix"))
 
         # if namespace taken from prefix attribute in head tag
         if match:


### PR DESCRIPTION
Fix this issue :

```
/usr/lib/python3/dist-packages/extruct/rdfa.py:88: SyntaxWarning: invalid escape sequence '\s'
     match = re.search(prefix + ": [^\s]+", head_element.get("prefix"))
```