### PR TITLE
fix: Add Support for lxml >= 5.2.0

### DIFF
--- a/extruct/xmldom.py
+++ b/extruct/xmldom.py
@@ -15,7 +15,7 @@ except ImportError:
 
     class _ElementStringResult(bytes):  # type: ignore[no-redef]
         """
-        _ElementStringResult is removed in lxml >= 5.1.0,
+        _ElementStringResult is removed in lxml >= 5.1.1,
         so we define it here for compatibility.
         """
 

--- a/extruct/xmldom.py
+++ b/extruct/xmldom.py
@@ -9,19 +9,6 @@ from xml.dom.minidom import Attr, NamedNodeMap
 from lxml.etree import ElementBase, XPath, _ElementUnicodeResult, tostring
 from lxml.html import HtmlElementClassLookup, HTMLParser
 
-try:
-    from lxml.etree import _ElementStringResult
-except ImportError:
-
-    class _ElementStringResult(bytes):
-        """
-        _ElementStringResult is removed in lxml >= 5.1.0,
-        so we define it here for compatibility.
-        """
-
-        def getparent(self):
-            return self._parent
-
 
 class DomElementUnicodeResult:
     CDATA_SECTION_NODE = Node.CDATA_SECTION_NODE
@@ -54,7 +41,7 @@ def lxmlDomNodeType(node):
     if isinstance(node, ElementBase):
         return Node.ELEMENT_NODE
 
-    elif isinstance(node, (_ElementStringResult, _ElementUnicodeResult)):
+    elif isinstance(node, _ElementUnicodeResult):
         if node.is_attribute:
             return Node.ATTRIBUTE_NODE
         else:
@@ -123,7 +110,7 @@ class DomHtmlMixin:
             if isinstance(n, ElementBase):
                 yield n
 
-            elif isinstance(n, (_ElementStringResult, _ElementUnicodeResult)):
+            elif isinstance(n, _ElementUnicodeResult):
 
                 if isinstance(n, _ElementUnicodeResult):
                     n = DomElementUnicodeResult(n)
@@ -149,7 +136,7 @@ class DomHtmlMixin:
 
     @property
     def data(self):
-        if isinstance(self, (_ElementStringResult, _ElementUnicodeResult)):
+        if isinstance(self, _ElementUnicodeResult):
             return self
         else:
             raise RuntimeError

--- a/extruct/xmldom.py
+++ b/extruct/xmldom.py
@@ -6,14 +6,21 @@ from copy import copy, deepcopy
 from xml.dom import Node
 from xml.dom.minidom import Attr, NamedNodeMap
 
-from lxml.etree import (
-    ElementBase,
-    XPath,
-    _ElementStringResult,
-    _ElementUnicodeResult,
-    tostring,
-)
+from lxml.etree import ElementBase, XPath, _ElementUnicodeResult, tostring
 from lxml.html import HtmlElementClassLookup, HTMLParser
+
+try:
+    from lxml.etree import _ElementStringResult
+except ImportError:
+
+    class _ElementStringResult(bytes):
+        """
+        _ElementStringResult is removed in lxml >= 5.1.0,
+        so we define it here for compatibility.
+        """
+
+        def getparent(self):
+            return self._parent
 
 
 class DomElementUnicodeResult:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # project requirements, install them using following command:
 # pip install -r requirements.txt
-lxml
+lxml>=5.2.0[html_clean]
 requests
 rdflib>=6.0.0; python_version>="3.7"
 rdflib<6.0.0; python_version<"3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # project requirements, install them using following command:
 # pip install -r requirements.txt
-lxml>=5.2.0[html_clean]
+lxml[html_clean]>=5.2.0
 requests
 rdflib>=6.0.0; python_version>="3.7"
 rdflib<6.0.0; python_version<"3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # project requirements, install them using following command:
 # pip install -r requirements.txt
-lxml[html_clean]>=5.2.0
+lxml[html_clean]
 requests
 rdflib>=6.0.0; python_version>="3.7"
 rdflib<6.0.0; python_version<"3.7"

--- a/tests/samples/misc/microformat_flat_test.json
+++ b/tests/samples/misc/microformat_flat_test.json
@@ -32,7 +32,10 @@
                     "aJ Styles FastLane 2018 15 x 17 Framed Plaque w/ Ring Canvas"
                 ],
                 "photo": [
-                    "/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg"
+                    {
+                        "alt": "aJ Styles FastLane 2018 15 x 17 Framed Plaque w/ Ring Canvas",
+                        "value": "/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg"
+                    }
                 ]
             }
         ]

--- a/tests/samples/misc/microformat_test.json
+++ b/tests/samples/misc/microformat_test.json
@@ -27,7 +27,11 @@
             {
                 "properties": {
                     "photo": [
-                        "/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg"
+                        {
+                            "alt": "aJ Styles FastLane 2018 15 x 17 Framed Plaque w/ Ring Canvas",
+                            "value": "/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg"
+
+                        }
                     ],
                     "name": [
                         "aJ Styles FastLane 2018 15 x 17 Framed Plaque w/ Ring Canvas"

--- a/tests/test_uniform.py
+++ b/tests/test_uniform.py
@@ -167,7 +167,10 @@ class TestUniform(unittest.TestCase):
                             "Canvas"
                         ],
                         "photo": [
-                            "/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg"
+                            {
+                              "alt": "aJ Styles FastLane 2018 15 x 17 Framed Plaque w/ Ring Canvas",
+                              "value": "/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg"   
+                            }
                         ],
                     },
                 ],

--- a/tests/test_uniform.py
+++ b/tests/test_uniform.py
@@ -168,8 +168,8 @@ class TestUniform(unittest.TestCase):
                         ],
                         "photo": [
                             {
-                              "alt": "aJ Styles FastLane 2018 15 x 17 Framed Plaque w/ Ring Canvas",
-                              "value": "/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg"   
+                                "alt": "aJ Styles FastLane 2018 15 x 17 Framed Plaque w/ Ring Canvas",
+                                "value": "/on/demandware.static/-/Sites-main/default/dwa3227ee6/images/small/CN1148.jpg",
                             }
                         ],
                     },


### PR DESCRIPTION
lxml 5.1.0 removed _ElementStringResult which we use during dom traversal. This PR attempts to import _ElementStringResult as usual, but falls back to defining it explicitly if the import fails. This fixes https://github.com/scrapinghub/extruct/issues/215

I chose to attempt to import first to preserve existing behavior if an older version of lxml is installed.

Additionally, we use the lxml HTML cleaner, which is now in its own separate package. Due to this I've added the optional html_clean package to the requirements.txt. As noted below, this raises a warning if using lxml < 5.2.0, but otherwise doesn't impact older versions.