### PR TITLE
fix: remove py2 utf8 encoding

### DIFF
--- a/extruct/jsonld.py
+++ b/extruct/jsonld.py
@@ -1,5 +1,4 @@
 # mypy: disallow_untyped_defs=False
-# -*- coding: utf-8 -*-
 """
 JSON-LD extractor
 """

--- a/extruct/rdfa.py
+++ b/extruct/rdfa.py
@@ -1,5 +1,4 @@
 # mypy: disallow_untyped_defs=False
-# -*- coding: utf-8 -*-
 """
 RDFa extractor
 

--- a/extruct/utils.py
+++ b/extruct/utils.py
@@ -1,5 +1,4 @@
 # mypy: disallow_untyped_defs=False
-# -*- coding: utf-8 -*-
 import lxml.html
 
 from extruct.xmldom import XmlDomHTMLParser

--- a/extruct/xmldom.py
+++ b/extruct/xmldom.py
@@ -1,7 +1,6 @@
 # mypy: disallow_untyped_defs=False
 from __future__ import annotations
 
-# -*- coding: utf-8 -*-
 from copy import copy, deepcopy
 from xml.dom import Node
 from xml.dom.minidom import Attr, NamedNodeMap

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 # mypy: disallow_untyped_defs=False
-# -*- coding: utf-8 -*-
 import os
 
 from setuptools import find_packages, setup

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,4 @@
 # mypy: disallow_untyped_defs=False
-# -*- coding: utf-8 -*-
 import json
 import os
 

--- a/tests/test_dublincore.py
+++ b/tests/test_dublincore.py
@@ -1,5 +1,4 @@
 # mypy: disallow_untyped_defs=False
-# -*- coding: utf-8 -*-
 import json
 import unittest
 

--- a/tests/test_extruct.py
+++ b/tests/test_extruct.py
@@ -1,5 +1,4 @@
 # mypy: disallow_untyped_defs=False
-# -*- coding: utf-8 -*-
 import json
 import unittest
 

--- a/tests/test_extruct_uniform.py
+++ b/tests/test_extruct_uniform.py
@@ -1,5 +1,4 @@
 # mypy: disallow_untyped_defs=False
-# -*- coding: utf-8 -*-
 import json
 import unittest
 

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -1,5 +1,4 @@
 # mypy: disallow_untyped_defs=False
-# -*- coding: utf-8 -*-
 import json
 import unittest
 

--- a/tests/test_microdata.py
+++ b/tests/test_microdata.py
@@ -1,5 +1,4 @@
 # mypy: disallow_untyped_defs=False
-# -*- coding: utf-8 -*-
 import json
 import unittest
 

--- a/tests/test_microformat.py
+++ b/tests/test_microformat.py
@@ -1,5 +1,4 @@
 # mypy: disallow_untyped_defs=False
-# -*- coding: utf-8 -*-
 import json
 import unittest
 

--- a/tests/test_opengraph.py
+++ b/tests/test_opengraph.py
@@ -1,5 +1,4 @@
 # mypy: disallow_untyped_defs=False
-# -*- coding: utf-8 -*-
 import json
 import unittest
 

--- a/tests/test_rdfa.py
+++ b/tests/test_rdfa.py
@@ -1,5 +1,4 @@
 # mypy: disallow_untyped_defs=False
-# -*- coding: utf-8 -*-
 import json
 import unittest
 from pprint import pformat


### PR DESCRIPTION
Not required for python 3. Every file is utf8.

## Reference

 #221