### PR TITLE
Skip empty JSON-LD scripts by trimming and skipping empty input

### DIFF
--- a/extruct/jsonld.py
+++ b/extruct/jsonld.py
@@ -34,7 +34,8 @@ class JsonLdExtractor:
 
     def _extract_items(self, node):
         script = node.xpath("string()").strip()
-        if not script: return
+        if not script:
+            return
         try:
             # TODO: `strict=False` can be configurable if needed
             data = json.loads(script, strict=False)

--- a/extruct/jsonld.py
+++ b/extruct/jsonld.py
@@ -33,7 +33,8 @@ class JsonLdExtractor:
         ]
 
     def _extract_items(self, node):
-        script = node.xpath("string()")
+        script = node.xpath("string()").strip()
+        if not script: return
         try:
             # TODO: `strict=False` can be configurable if needed
             data = json.loads(script, strict=False)

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -63,3 +63,9 @@ class TestJsonLD(unittest.TestCase):
         jsonlde = JsonLdExtractor()
         data = jsonlde.extract(body)
         self.assertEqual(data, expected)
+
+    def test_empty_jsonld_script(self):
+        jsonlde = JsonLdExtractor()
+        body = '<script type="application/ld+json">   \n\n  </script>'
+        data = jsonlde.extract(body)
+        self.assertEqual(data, [])


### PR DESCRIPTION
Skipping empty JSON-LD scripts prevents parsing issues with blank data.